### PR TITLE
Added hover border, swapped rounded corners

### DIFF
--- a/nengo_viz/static/viz_netgraph.css
+++ b/nengo_viz/static/viz_netgraph.css
@@ -51,10 +51,10 @@ g.net rect{
 
 .netgraph rect.highlight {
     stroke-width: 1;
-    stroke: #888;
+    stroke: rgba(0,0,0,0.1);
 }
 
 .netgraph rect.dragging {
     stroke-width: 1;
-    stroke: #888;
+    stroke: rgba(0,0,0,0.1);
 }

--- a/nengo_viz/static/viz_netgraph.css
+++ b/nengo_viz/static/viz_netgraph.css
@@ -43,3 +43,18 @@ g.net rect{
     dominant-baseline: text-before-edge;
     }    
 
+.netgraph rect.border {
+    stroke-width: 0;
+    stroke: black;
+    fill: transparent;
+}
+
+.netgraph rect.highlight {
+    stroke-width: 1;
+    stroke: #888;
+}
+
+.netgraph rect.dragging {
+    stroke-width: 1;
+    stroke: #888;
+}

--- a/nengo_viz/static/viz_netgraph_item.js
+++ b/nengo_viz/static/viz_netgraph_item.js
@@ -136,7 +136,8 @@ VIZ.NetGraphItem = function(ng, info) {
         var tmp = this.border === undefined ? this.shape : this.border;
         interact(tmp)
             .resizable({
-                edges: { left: true, right: true, bottom: true, top: true }
+                edges: { left: true, right: true, bottom: true, top: true },
+                invert: 'reposition'
                 })
             .on('resizestart', function(event) {
                 self.menu.hide_any();
@@ -170,12 +171,6 @@ VIZ.NetGraphItem = function(ng, info) {
                     if (event.edges.bottom) {
                         h *= -1;
                     }
-                    if (w < 0) {
-                        w = 1;
-                    }
-                    if (h < 0) {
-                        h = 1;
-                    }
 
                     var screen_w = self.get_width();
                     var screen_h = self.get_height();
@@ -189,6 +184,11 @@ VIZ.NetGraphItem = function(ng, info) {
                         h = w / self.aspect;
                     } else {
                         w = h * self.aspect;
+                    }
+
+                    if (w < 0 && h < 0) {
+                        w = -w;
+                        h = -h;
                     }
 
                     var scaled_w = w / h_scale;

--- a/nengo_viz/static/viz_netgraph_item.js
+++ b/nengo_viz/static/viz_netgraph_item.js
@@ -182,7 +182,7 @@ VIZ.NetGraphItem = function(ng, info) {
 
                     if (horizontal_resize && vertical_resize) {
                         var p = (screen_w * w + screen_h * h) / Math.sqrt(
-                            screen_w * screen_w + screen_h * screen_h);
+                            2 * (screen_w * screen_w + screen_h * screen_h));
                         h = p / self.aspect;
                         w = p * self.aspect;
                     } else if (horizontal_resize) {

--- a/nengo_viz/static/viz_netgraph_item.js
+++ b/nengo_viz/static/viz_netgraph_item.js
@@ -635,7 +635,7 @@ VIZ.NetGraphItem.prototype.redraw_size = function() {
         }
     }
     if (this.border !== undefined) {
-        var border_w = screen_w + 6;
+        var border_w = screen_w * 0.97 + 6;
         var border_h = screen_h + 6;
 
         this.border.setAttribute('width', border_w);
@@ -644,10 +644,9 @@ VIZ.NetGraphItem.prototype.redraw_size = function() {
             'translate(-' + (border_w / 2) + ', -' + (border_h / 2) + ')');
     }
 
-
     if (this.type === 'ens') {
         var scale = Math.sqrt(screen_h * screen_h + screen_w * screen_w) / Math.sqrt(2);
-        var r = 18;  //TODO: Don't hardcode the size of the ensemble
+        var r = 17.8;  //TODO: Don't hardcode the size of the ensemble
         this.shape.setAttribute('transform', 'scale(' + scale / 2 / r + ')');
         this.shape.style.setProperty('stroke-width', 20/scale);              
     } else if (this.passthrough) {
@@ -751,25 +750,26 @@ VIZ.NetGraphItem.prototype.ensemble_svg = function() {
     var shape = this.ng.createSVGElement('g');
     shape.setAttribute('class', 'ensemble');        
 
-    dx = -0.5;
+    var dx = -1.25;
+    var dy = 0.25;
     
     var circle = this.ng.createSVGElement('circle');
-    this.setAttributes(circle, {'cx':-11.157 + dx,'cy':'-7.481','r':'4.843'});
+    this.setAttributes(circle, {'cx':-11.157 + dx,'cy':-7.481 + dy,'r':'4.843'});
     shape.appendChild(circle);
     var circle = this.ng.createSVGElement('circle');
-    this.setAttributes(circle, {'cx':0.186 + dx,'cy':'-0.127','r':'4.843'});
+    this.setAttributes(circle, {'cx':0.186 + dx,'cy':-0.127 + dy,'r':'4.843'});
     shape.appendChild(circle);
     var circle = this.ng.createSVGElement('circle');
-    this.setAttributes(circle, {'cx':5.012 + dx,'cy':'12.56','r':'4.843'});
+    this.setAttributes(circle, {'cx':5.012 + dx,'cy':12.56 + dy,'r':'4.843'});
     shape.appendChild(circle);
     var circle = this.ng.createSVGElement('circle');
-    this.setAttributes(circle, {'cx':13.704 + dx,'cy':'-0.771','r':'4.843'});
+    this.setAttributes(circle, {'cx':13.704 + dx,'cy':-0.771 + dy,'r':'4.843'});
     shape.appendChild(circle);
     var circle = this.ng.createSVGElement('circle');
-    this.setAttributes(circle, {'cx':-10.353 + dx,'cy':'8.413','r':'4.843'});
+    this.setAttributes(circle, {'cx':-10.353 + dx,'cy':8.413 + dy,'r':'4.843'});
     shape.appendChild(circle);            
     var circle = this.ng.createSVGElement('circle');
-    this.setAttributes(circle, {'cx':3.894 + dx,'cy':'-13.158','r':'4.843'});
+    this.setAttributes(circle, {'cx':3.894 + dx,'cy':-13.158 + dy,'r':'4.843'});
     shape.appendChild(circle);
 
     var main_circle = this.ng.createSVGElement('circle');

--- a/nengo_viz/static/viz_netgraph_item.js
+++ b/nengo_viz/static/viz_netgraph_item.js
@@ -634,9 +634,14 @@ VIZ.NetGraphItem.prototype.redraw_size = function() {
             screen_h = screen_w / this.aspect;
         }
     }
+
+    var border_size = 3;
     if (this.border !== undefined) {
-        var border_w = screen_w * 0.97 + 6;
-        var border_h = screen_h + 6;
+        var border_w = screen_w + border_size * 2;
+        var border_h = screen_h + border_size * 2;
+        if (this.type == 'ens') {
+            border_w = screen_w * 0.97 + border_size * 2;
+        }
 
         this.border.setAttribute('width', border_w);
         this.border.setAttribute('height', border_h);
@@ -667,7 +672,8 @@ VIZ.NetGraphItem.prototype.redraw_size = function() {
                'translate(-' + (screen_w / 2) + ', -' + (screen_h / 2) + ')');
     }
     
-    this.label.setAttribute('transform', 'translate(0, ' + (screen_h / 2) + ')');
+    this.label.setAttribute('transform', 'translate(0, ' + 
+                                         ((screen_h / 2) + border_size) + ')');
 };
 
 VIZ.NetGraphItem.prototype.get_width = function() {

--- a/nengo_viz/static/viz_netgraph_item.js
+++ b/nengo_viz/static/viz_netgraph_item.js
@@ -57,21 +57,19 @@ VIZ.NetGraphItem = function(ng, info) {
 
     this.menu = new VIZ.Menu(this.ng.parent);
 
-    if (info.type !== 'net') {
-        this.border = this.ng.createSVGElement('rect');
-        this.border.classList.add('border');
-        g.appendChild(this.border);
+    this.border = this.ng.createSVGElement('rect');
+    this.border.classList.add('border');
+    g.appendChild(this.border);
 
-        this.g.addEventListener('mouseenter',
-                                function() {
-                                    self.border.classList.add('highlight');
-                                });
-        this.g.addEventListener('mouseleave',
-                                function() {
-                                    self.border.classList.remove('highlight');
-                                });
-    }
-    
+    this.g.addEventListener('mouseenter',
+                            function() {
+                                self.border.classList.add('highlight');
+                            });
+    this.g.addEventListener('mouseleave',
+                            function() {
+                                self.border.classList.remove('highlight');
+                            });
+
     /** different types use different SVG elements for display */
     if (info.type === 'node') {
         if (this.passthrough) {
@@ -637,11 +635,16 @@ VIZ.NetGraphItem.prototype.redraw_size = function() {
         }
     }
     if (this.border !== undefined) {
-        this.border.setAttribute('width', screen_w);
-        this.border.setAttribute('height', screen_h);
+        var border_w = screen_w + 6;
+        var border_h = screen_h + 6;
+
+        this.border.setAttribute('width', border_w);
+        this.border.setAttribute('height', border_h);
         this.border.setAttribute('transform', 
-            'translate(-' + (screen_w / 2) + ', -' + (screen_h / 2) + ')');
+            'translate(-' + (border_w / 2) + ', -' + (border_h / 2) + ')');
     }
+
+
     if (this.type === 'ens') {
         var scale = Math.sqrt(screen_h * screen_h + screen_w * screen_w) / Math.sqrt(2);
         var r = 18;  //TODO: Don't hardcode the size of the ensemble
@@ -659,8 +662,6 @@ VIZ.NetGraphItem.prototype.redraw_size = function() {
         var radius = Math.min(screen_w, screen_h);
         this.shape.setAttribute('rx', radius*.2);
         this.shape.setAttribute('ry', radius*.2);
-        screen_w *= 0.95;
-        screen_h *= 0.95;
         this.shape.setAttribute('width', screen_w);
         this.shape.setAttribute('height', screen_h);
         this.shape.setAttribute('transform', 
@@ -749,24 +750,26 @@ VIZ.NetGraphItem.prototype.get_screen_location = function() {
 VIZ.NetGraphItem.prototype.ensemble_svg = function() {
     var shape = this.ng.createSVGElement('g');
     shape.setAttribute('class', 'ensemble');        
+
+    dx = -0.5;
     
     var circle = this.ng.createSVGElement('circle');
-    this.setAttributes(circle, {'cx':'-11.157','cy':'-7.481','r':'4.843'});
+    this.setAttributes(circle, {'cx':-11.157 + dx,'cy':'-7.481','r':'4.843'});
     shape.appendChild(circle);
     var circle = this.ng.createSVGElement('circle');
-    this.setAttributes(circle, {'cx':'0.186','cy':'-0.127','r':'4.843'});
+    this.setAttributes(circle, {'cx':0.186 + dx,'cy':'-0.127','r':'4.843'});
     shape.appendChild(circle);
     var circle = this.ng.createSVGElement('circle');
-    this.setAttributes(circle, {'cx':'5.012','cy':'12.56','r':'4.843'});
+    this.setAttributes(circle, {'cx':5.012 + dx,'cy':'12.56','r':'4.843'});
     shape.appendChild(circle);
     var circle = this.ng.createSVGElement('circle');
-    this.setAttributes(circle, {'cx':'13.704','cy':'-0.771','r':'4.843'});
+    this.setAttributes(circle, {'cx':13.704 + dx,'cy':'-0.771','r':'4.843'});
     shape.appendChild(circle);
     var circle = this.ng.createSVGElement('circle');
-    this.setAttributes(circle, {'cx':'-10.353','cy':'8.413','r':'4.843'});
+    this.setAttributes(circle, {'cx':-10.353 + dx,'cy':'8.413','r':'4.843'});
     shape.appendChild(circle);            
     var circle = this.ng.createSVGElement('circle');
-    this.setAttributes(circle, {'cx':'3.894','cy':'-13.158','r':'4.843'});
+    this.setAttributes(circle, {'cx':3.894 + dx,'cy':'-13.158','r':'4.843'});
     shape.appendChild(circle);
 
     var main_circle = this.ng.createSVGElement('circle');


### PR DESCRIPTION
This adds an outline around Ensembles and Nodes when mouseover,
and moves uses that outline for the resizing.  We also make
Networks have straight corners and Nodes have rounded corners.
This fixes the resizing problems (including the bottom corners)