### PR TITLE
Add option to make expanded networks transparent

### DIFF
--- a/nengo_gui/static/modal.js
+++ b/nengo_gui/static/modal.js
@@ -160,6 +160,15 @@ Nengo.Modal.prototype.main_config = function(options) {
             '<input type="checkbox" id="fixed-resize">' +
             'Fix aspect ratio of elements on canvas resize' +
           '</label>' +
+          '<div class="help-block with-errors"></div>' +
+        '</div>' +
+      '</div>' +
+      '<div class="form-group">' +
+        '<div class="checkbox">' +
+          '<label for="transparent-nets" class="control-label">' +
+            '<input type="checkbox" id="transparent-nets">' +
+            'Expanded networks are transparent' +
+          '</label>' +
         '<div class="help-block with-errors"></div>' +
       '</div>' +
       '<div class="select">' +
@@ -183,6 +192,12 @@ Nengo.Modal.prototype.main_config = function(options) {
     $('#fixed-resize').prop('checked', options["aspect_resize"]);
 
     $('#config-fontsize').val(options["font_size"]);
+
+    $('#transparent-nets').prop('checked', options["transparent_nets"]);
+    $('#transparent-nets').change(function () {
+        Nengo.netgraph.transparent_nets = $('#transparent-nets').prop('checked');
+    });
+
     $('#config-fontsize').bind('keyup input', function () {
         Nengo.netgraph.set_font_size(parseInt($('#config-fontsize').val()));
     });

--- a/nengo_gui/static/netgraph.js
+++ b/nengo_gui/static/netgraph.js
@@ -17,6 +17,24 @@ Nengo.NetGraph = function(parent, args) {
     this.font_size = 100;       // font size as a percent of base
     this.aspect_resize = false;  //preserve aspect ratios on window resize
 
+    var transparent_nets = false;  // Do networks have transparent backgrounds?
+    Object.defineProperty(this, 'transparent_nets', {
+        get: function() {
+            return transparent_nets;
+        },
+        set: function(val) {
+            if (val === transparent_nets) { return; }
+            transparent_nets = val;
+            for (var key in this.svg_objects) {
+                var ngi = this.svg_objects[key];
+                ngi.compute_fill();
+                if (ngi.type === 'net' && ngi.expanded) {
+                    ngi.shape.style["fill-opacity"] = val ? 0.0 : 1.0;
+                }
+            }
+        }
+    });
+
     this.svg_objects = {};     // dict of all Nengo.NetGraphItems, by uid
     this.svg_conns = {};       // dict of all Nengo.NetGraphConnections, by uid
     this.minimap_objects = {};
@@ -439,7 +457,7 @@ Nengo.NetGraph.prototype.on_resize = function(event) {
                     this.old_width/width / this.scale;
                 var new_height = item.get_height()*
                     this.old_height/height / this.scale;
-                item.size = [new_width/(2*width), 
+                item.size = [new_width/(2*width),
                     new_height/(2*height)];               }
         }
     }
@@ -447,7 +465,7 @@ Nengo.NetGraph.prototype.on_resize = function(event) {
     this.old_width = width;
     this.old_height = height;
 
-    this.redraw();    
+    this.redraw();
 };
 
 

--- a/nengo_gui/static/netgraph_item.js
+++ b/nengo_gui/static/netgraph_item.js
@@ -403,6 +403,9 @@ Nengo.NetGraphItem.prototype.expand = function(rts, auto) {
 
     if (!this.expanded) {
         this.expanded = true;
+        if (this.ng.transparent_nets) {
+            this.shape.style["fill-opacity"] = 0.0;
+        }
         this.g_items.removeChild(this.g);
         this.g_networks.appendChild(this.g);
         if (this.minimap == false) {
@@ -448,6 +451,9 @@ Nengo.NetGraphItem.prototype.collapse = function(report_to_server, auto) {
 
     if (this.expanded) {
         this.expanded = false;
+        if (this.ng.transparent_nets) {
+            this.shape.style["fill-opacity"] = 1.0;
+        }
         this.g_networks.removeChild(this.g);
         this.g_items.appendChild(this.g);
         if (this.minimap == false) {
@@ -471,10 +477,12 @@ Nengo.NetGraphItem.prototype.collapse = function(report_to_server, auto) {
 
 /** determine the fill color based on the depth */
 Nengo.NetGraphItem.prototype.compute_fill = function() {
+    var depth = this.ng.transparent_nets ? 1 : this.depth;
+
     if (!this.passthrough) {
-        var fill = Math.round(255 * Math.pow(0.8, this.depth));
+        var fill = Math.round(255 * Math.pow(0.8, depth));
         this.shape.style.fill = 'rgb(' + fill + ',' + fill + ',' + fill + ')';
-        var stroke = Math.round(255 * Math.pow(0.8, this.depth + 2));
+        var stroke = Math.round(255 * Math.pow(0.8, depth + 2));
         this.shape.style.stroke = 'rgb(' + stroke + ',' + stroke + ',' + stroke + ')';
     }
 }

--- a/nengo_gui/static/top_toolbar.js
+++ b/nengo_gui/static/top_toolbar.js
@@ -101,9 +101,9 @@ Nengo.Toolbar.prototype.config_modal_show = function() {
     var self = this;
 
     var options = {zoom: Nengo.netgraph.zoom_fonts,
-        font_size: Nengo.netgraph.font_size,
-        aspect_resize: Nengo.netgraph.aspect_resize
-        };
+                   font_size: Nengo.netgraph.font_size,
+                   aspect_resize: Nengo.netgraph.aspect_resize,
+                   transparent_nets: Nengo.netgraph.transparent_nets};
 
     Nengo.modal.title('Configure Options');
     Nengo.modal.main_config(options);


### PR DESCRIPTION
This is a bit of an experiment to see what it looks like when expanded networks are transparent, with just the border shown. I've been thinking for some time that this is the right way to render networks, but it's hard to convince even myself without actually seeing it. Having seen it now, I do like it, but will leave it to the consensus.

Note that this is still considered a WIP because I just did the minimal implementation in order to get it to work; the code needs to be looked at by someone more knowledgable with this part of the code base. Also, if the consensus thinks this is good, then we can remove some additional existing code; for example, we could remove `compute_fill` because we don't have to worry about the infinite depth issue.
A network is either collapsed (grey), or expanded (transparent).

Some example screenshots from `examples/net.py`.

First, with everything collapsed (same as before):

![collapsed](https://cloud.githubusercontent.com/assets/203709/7903894/10655f66-07b8-11e5-97a5-07cd26ca03f3.png)

With subnet expanded:

![subnet](https://cloud.githubusercontent.com/assets/203709/7903896/17538870-07b8-11e5-98a9-4e50fdcb8628.png)

With subsubnet expanded

![subsubnet](https://cloud.githubusercontent.com/assets/203709/7903897/1e17eaa2-07b8-11e5-9262-0758c0bbd4fa.png)
