### PR TITLE
Fix the spacebar problem with the editor

### DIFF
--- a/nengo_gui/static/hotkeys.js
+++ b/nengo_gui/static/hotkeys.js
@@ -2,10 +2,9 @@ Nengo.Hotkeys = function () {
     var self = this;
 
     document.addEventListener('keydown', function(ev) {
-        // ignore keypresses going to the editor
-        if (ev.target.className === 'ace_text-input') {
-            return;
-        }
+
+        var on_editor = (ev.target.className === 'ace_text-input');
+
         if (typeof ev.key != 'undefined') {
             var key = ev.key;
         } else {
@@ -41,14 +40,14 @@ Nengo.Hotkeys = function () {
             ev.preventDefault();
         }
         // run model with spacebar
-        if (key == ' ') {
+        if (key == ' ' && !on_editor) {
             if (!ev.repeat) {
                 sim.on_pause_click();
             }
             ev.preventDefault();
         }
         // bring up help menu with ?
-        if (key == '?') {
+        if (key == '?' && !on_editor) {
             self.callMenu();
             ev.preventDefault();
         }

--- a/nengo_gui/static/hotkeys.js
+++ b/nengo_gui/static/hotkeys.js
@@ -2,6 +2,10 @@ Nengo.Hotkeys = function () {
     var self = this;
 
     document.addEventListener('keydown', function(ev) {
+        // ignore keypresses going to the editor
+        if (ev.target.className === 'ace_text-input') {
+            return;
+        }
         if (typeof ev.key != 'undefined') {
             var key = ev.key;
         } else {

--- a/nengo_gui/static/netgraph.js
+++ b/nengo_gui/static/netgraph.js
@@ -123,6 +123,9 @@ Nengo.NetGraph = function(parent, args) {
      *  Note that offsetX,Y are also changed to zoom into a particular
      *  point in the space */
     interact(document.getElementById('main'))
+        .on('click', function(event) {
+            $('.ace_text-input').blur();
+        })
         .on('wheel', function(event) {
             event.preventDefault();
 


### PR DESCRIPTION
Here's a quick fix for the spacebar problem.

It's not perfect because you can't click on the NetGraph to change focus (the text editor keeps the focus).  But if you click on the top or bottom bar, hotkeys will now work as expected.