### PR TITLE
made minimap position relative, doesn't push menu out of position anymore

### DIFF
--- a/nengo_gui/static/main.css
+++ b/nengo_gui/static/main.css
@@ -36,7 +36,7 @@ div.minimap {
     width: 15%;
     left: 84.5%;
     top: 82.5%;
-    position: absolute;
+    position: relative;
     z-index: 99999999;
 }
 


### PR DESCRIPTION
Menus were previously being pushed out of position, changing minimap div to position:relative fixes this issue.