### PR TITLE
Placed menu so cursor is on first item

### DIFF
--- a/nengo_gui/static/menu.js
+++ b/nengo_gui/static/menu.js
@@ -30,8 +30,8 @@ Nengo.Menu.prototype.show = function (x, y, items) {
     // TODO: move this to the constructor
     this.menu_div = document.createElement('div');
     this.menu_div.style.position = 'fixed';
-    this.menu_div.style.left = x;
-    this.menu_div.style.top = y;
+    this.menu_div.style.left = x - 20; // offset menu so that it appears
+    this.menu_div.style.top = y - 20;  //  with the cursor on the first item
     this.menu_div.style.zIndex = Nengo.next_zindex();
 
     this.menu = document.createElement('ul');


### PR DESCRIPTION
I usually like menus to appear positioned such that the mouse cursor is over the first item.  That's what nengo_gui had been doing up until yesterday, but the current master does not.  Instead, it positions the menu such that the top-left corner is under the mouse cursor.

This PR adds in that offset again.  However, I do want to get feedback on whether we want that offset.  One argument against the offset is that without the offset if you right-click accidentally, you can immediately left-click and the menu goes away (instead of selecting whatever the first item is). 

Thoughts? 