### PR TITLE
Refactor reload to fix reloading problems

### DIFF
--- a/nengo_gui/components/sim_control.py
+++ b/nengo_gui/components/sim_control.py
@@ -28,7 +28,6 @@ class SimControl(Component):
         self.time = 0.0
         self.last_status = None
         self.next_ping_time = None
-        self.reload = False
         self.send_config_options = False
 
     def add_nengo_objects(self, viz):
@@ -84,9 +83,6 @@ class SimControl(Component):
         if status != self.last_status:
             client.write('status:%s' % status)
             self.last_status = status
-        if self.reload == True:
-            client.write('reload')
-            self.reload = False
         if self.send_config_options == True:
             client.write('sims:' + self.backend_options_html())
             client.write('config' +
@@ -117,20 +113,6 @@ class SimControl(Component):
             if self.viz.sim is None:
                 self.viz.rebuild = True
             self.paused = False
-        elif msg[:4] == 'open':
-            try:
-                self.viz.viz.load(msg[4:])
-                self.reload = True
-            except:
-                traceback.print_exc()
-        elif msg == 'reset':
-            if os.path.isfile(self.viz.viz.config_name()) :
-                os.remove(self.viz.viz.config_name())
-            self.viz.viz.config = self.viz.viz.load_config()
-            self.viz.viz.load(
-                self.viz.viz.filename, self.viz.viz.model,
-                self.viz.viz.orig_locals)
-            self.reload = True
         elif msg[:8] == 'backend:':
             self.viz.backend = msg[8:]
             self.viz.changed = True
@@ -145,6 +127,7 @@ class SimControl(Component):
             item = '<option %s>%s</option>' % (selected, module)
             items.append(item)
         return ''.join(items)
+
 
 class SimControlTemplate(Template):
     cls = SimControl

--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -74,7 +74,7 @@ class Server(swi.SimpleWebInterface):
         if self.user is None:
             return self.create_login_form()
 
-        if reset is not None:
+        if reset == 'True':
             self.server.viz.load(self.server.viz.filename,
                 self.server.viz.model, self.server.viz.orig_locals,
                 reset=True)

--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -69,10 +69,17 @@ class Server(swi.SimpleWebInterface):
             <input type=submit value="Log In">
             </form>""" % message
 
-    def swi(self):
+    def swi(self, filename=None, reset=None):
         """Handles http://host:port/ by giving the main page"""
         if self.user is None:
             return self.create_login_form()
+
+        if reset is not None:
+            self.server.viz.load(self.server.viz.filename,
+                self.server.viz.model, self.server.viz.orig_locals,
+                reset=True)
+        elif filename is not None:
+            self.server.viz.load(filename, force=True)
 
         # create a new simulator
         viz_sim = self.server.viz.create_sim()

--- a/nengo_gui/static/sim_control.js
+++ b/nengo_gui/static/sim_control.js
@@ -68,9 +68,6 @@ Nengo.SimControl.prototype.on_message = function(event) {
         if (event.data.substring(0, 7) === 'status:') {
             this.set_status(event.data.substring(7));
         }
-        else if (event.data.substring(0, 6) === 'reload') {
-            location.reload();
-        }
         else if (event.data.substring(0, 6) === 'config') {
             console.log(event.data);
             eval(event.data.substring(6, event.data.length));

--- a/nengo_gui/static/top_toolbar.js
+++ b/nengo_gui/static/top_toolbar.js
@@ -48,6 +48,9 @@ Nengo.Toolbar = function(filename) {
 
     $('#filename')[0].innerHTML = filename;
 
+    // update the URL so reload and bookmarks work as expected
+    history.pushState({}, filename, '/?filename=' + filename);
+
     this.toolbar = $('#toolbar_object')[0];
 
     this.menu = new Nengo.Menu(this.toolbar);
@@ -69,8 +72,8 @@ Nengo.Toolbar.prototype.file_browser = function () {
             script: '/browse'
         },
         function (file) {
-            var msg = 'open' + file
-            sim.ws.send(msg);})
+            window.location.assign('/?filename=' + file);
+        })
     }
 };
 
@@ -85,7 +88,7 @@ Nengo.Toolbar.prototype.file_name = function() {
 /** Tells the server to reset the model layout to the default,
  *  by deleting the config file and reloading the script */
 Nengo.Toolbar.prototype.reset_model_layout = function () {
-    sim.ws.send('reset');
+    window.location.assign('/?reset=True');
 }
 
 /** Function called by event handler in order to launch modal.

--- a/nengo_gui/viz.py
+++ b/nengo_gui/viz.py
@@ -189,7 +189,8 @@ class Viz(object):
 
         self.load(filename, model, locals, force=True)
 
-    def load(self, filename, model=None, locals=None, force=False):
+    def load(self, filename, model=None, locals=None, force=False,
+             reset=False):
         with self.lock:
             try:
                 filename = os.path.relpath(filename)
@@ -250,6 +251,10 @@ class Viz(object):
             self.filename = filename
             self.name_finder = nengo_gui.NameFinder(locals, model)
             self.default_labels = self.name_finder.known_name
+
+            if reset:
+                if os.path.isfile(self.config_name()) :
+                    os.remove(self.config_name())
 
             self.config = self.load_config()
             self.config_save_needed = False


### PR DESCRIPTION
With the old system, we would occasionally get weird duplication bugs where things mostly don't work and there are two copies of the NetGraph (and other components).  These were accompanied by lots of "Error finding label" bugs.

This PR changes the load system so that instead of a two-part process where the internal Viz is updated and then the client does a reload, now the reloading is done in the actual swi page request itself (i.e. after the reload).  This means that we no longer have a period of time where the old page is connected to the server with the new content.  I believe the bug were due to information being passed to the client about the new page before the reload happens.