### PR TITLE
Created graphs now appear with a specific size

### DIFF
--- a/nengo_gui/static/netgraph_item.js
+++ b/nengo_gui/static/netgraph_item.js
@@ -368,13 +368,13 @@ Nengo.NetGraphItem.prototype.create_graph = function (type, args) {
     info.x = pos[0] / (viewport.w * viewport.scale) - viewport.x + w;
     info.y = pos[1] / (viewport.h * viewport.scale) - viewport.y + h;
 
+    info.width = 100 / (viewport.w * viewport.scale);
+    info.height = 100 / (viewport.h * viewport.scale);
 
     if (info.type == 'Slider') {
-        info.width = w*0.5;
-    } else {
-        info.width = w*2;
+        info.width /= 2;
     }
-    info.height = h*2;
+
     info.uid = this.uid;
     if (typeof(args) != 'undefined') { info.args = args; }
     this.ng.notify(info);


### PR DESCRIPTION
They used to be sized based on the size of the component
that the graph is about.  Now they are generated at a fixed
200px by 200px size. (Sliders are at half that width).