### PR TITLE
Handle IOErrors when saving file

### DIFF
--- a/nengo_gui/components/ace_editor.py
+++ b/nengo_gui/components/ace_editor.py
@@ -35,8 +35,11 @@ class AceEditor(Component):
         self.current_code = data['code']
 
         if data['save']:
-            with open(self.viz.viz.filename, 'w') as f:
-                f.write(self.current_code)
+            try:
+                with open(self.viz.viz.filename, 'w') as f:
+                    f.write(self.current_code)
+            except IOError:
+                self.viz.new_code = self.current_code
         else:
             self.viz.new_code = self.current_code
 

--- a/nengo_gui/components/ace_editor.py
+++ b/nengo_gui/components/ace_editor.py
@@ -39,6 +39,8 @@ class AceEditor(Component):
                 with open(self.viz.viz.filename, 'w') as f:
                     f.write(self.current_code)
             except IOError:
+                print("Could not save %s; permission denied" %
+                      self.viz.viz.filename)
                 self.viz.new_code = self.current_code
         else:
             self.viz.new_code = self.current_code

--- a/nengo_gui/viz.py
+++ b/nengo_gui/viz.py
@@ -352,8 +352,12 @@ class Viz(object):
         with self.lock:
             self.config_save_time = now_time
             self.config_save_needed = False
-            with open(self.config_name(), 'w') as f:
-                f.write(self.config.dumps(uids=self.default_labels))
+            try:
+                with open(self.config_name(), 'w') as f:
+                    f.write(self.config.dumps(uids=self.default_labels))
+            except IOError:
+                print("Could not save %s; permission denied" %
+                      self.config_name())
 
     def modified_config(self):
         self.config_save_needed = True


### PR DESCRIPTION
This at least stops the editor from dying when you try to save a read-only file.  But there should also be some sort of visual feedback that it didn't save.