### PR TITLE
Makes sliders reset on simulation restart

### DIFF
--- a/nengo_gui/components/slider.py
+++ b/nengo_gui/components/slider.py
@@ -10,6 +10,7 @@ class Slider(Component):
         self.node = node
         self.base_output = node.output
         self.override = [None] * node.size_out
+        self.last_time = None
         self.value = np.zeros(node.size_out)
         self.label = viz.viz.get_label(node)
         self.start_value = np.zeros(node.size_out, dtype=float)
@@ -25,6 +26,9 @@ class Slider(Component):
         self.node.output = self.base_output
 
     def override_output(self, t, *args):
+        if self.last_time is None or t < self.last_time:
+            self.override = [None] * self.node.size_out
+        self.last_time = t
         if callable(self.base_output):
             self.value[:] = self.base_output(t, *args)
             self.data.append(self.struct.pack(t, *self.value))


### PR DESCRIPTION
The slider resetting system wasn't working in the
case where the simulation was being reset due to new graphs
being created.  I believe this is at least part of the problems
noted in https://github.com/nengo/nengo_gui/pull/426#issuecomment-112223850

To replicate, run a model with a graph and a slider.  Move the slider around a bit and leave it at a non-zero value.  Now make a new graph.  Hit play again.  Without this fix the Node will continue to output the old value, even though the slider moves back to its original value.  With this fix the Node's output value will be reset.