### PR TITLE
Fix window bug with repeating aborted connections

### DIFF
--- a/nengo_gui/swi.py
+++ b/nengo_gui/swi.py
@@ -601,6 +601,8 @@ class ClientSocket(object):
                 pass
             elif e.errno == 9:  # "Bad file descriptor" means socket closed
                 raise SocketClosedError("Cannot read from closed socket.")
+            elif e.errno == 10053:  # aborted connection
+                raise SocketClosedError("Cannot read from closed socket.")
             else:
                 raise
         except socket.timeout:


### PR DESCRIPTION
Occasionally when shutting things down on Windows, I get:

```
Traceback (most recent call last):
  File "c:\users\terry\documents\github\nengo_gui\nengo_gui\server.py", line 125, in ws_viz_component
    msg = client.read()
  File "c:\users\terry\documents\github\nengo_gui\nengo_gui\swi.py", line 594, in read
    data = data + bytearray(self.socket.recv(512))
error: [Errno 10053] An established connection was aborted by the software in your host machine
Traceback (most recent call last):
  File "c:\users\terry\documents\github\nengo_gui\nengo_gui\server.py", line 125, in ws_viz_component
    msg = client.read()
  File "c:\users\terry\documents\github\nengo_gui\nengo_gui\swi.py", line 594, in read
    data = data + bytearray(self.socket.recv(512))
error: [Errno 10053] An established connection was aborted by the software in your host machine
Traceback (most recent call last):
  File "c:\users\terry\documents\github\nengo_gui\nengo_gui\server.py", line 125, in ws_viz_component
    msg = client.read()
  File "c:\users\terry\documents\github\nengo_gui\nengo_gui\swi.py", line 594, in read
    data = data + bytearray(self.socket.recv(512))
error: [Errno 10053] An established connection was aborted by the software in your host machine
```
repeated forever and ever.  This PR should let the system notice this failure.