### PR TITLE
Prefiltered xy plots as well

### DIFF
--- a/nengo_gui/components/xyvalue.py
+++ b/nengo_gui/components/xyvalue.py
@@ -20,7 +20,7 @@ class XYValue(Component):
         with viz.model:
             self.node = nengo.Node(self.gather_data,
                                    size_in=self.obj.size_out)
-            self.conn = nengo.Connection(self.obj, self.node, synapse=None)
+            self.conn = nengo.Connection(self.obj, self.node, synapse=0.01)
 
     def remove_nengo_objects(self, viz):
         viz.model.connections.remove(self.conn)

--- a/nengo_gui/static/xyvalue.js
+++ b/nengo_gui/static/xyvalue.js
@@ -17,7 +17,7 @@ Nengo.XYValue = function(parent, sim, args) {
     this.sim = sim;
 
     /** for storing the accumulated data */
-    this.data_store = new Nengo.DataStore(this.n_lines, this.sim, 0.01);
+    this.data_store = new Nengo.DataStore(this.n_lines, this.sim, 0);
 
     this.axes2d = new Nengo.Axes2D(this.div, args);
     this.axes2d.axis_y.tickValues([args.min_value, args.max_value]);


### PR DESCRIPTION
This applies the #461 fix (filtering in nengo, rather than in javascript) to XY plots, for consistency