### PR TITLE
deactivate hotkeys when modal is active

### DIFF
--- a/nengo_gui/static/hotkeys.js
+++ b/nengo_gui/static/hotkeys.js
@@ -4,62 +4,62 @@ Nengo.Hotkeys = function () {
     this.active = true;
     
     document.addEventListener('keydown', function(ev) {
-    if (self.active) {
+        if (self.active) {
 
-        var on_editor = (ev.target.className === 'ace_text-input');
+            var on_editor = (ev.target.className === 'ace_text-input');
 
-        if (typeof ev.key != 'undefined') {
-            var key = ev.key;
-        } else {
-            switch (ev.keyCode) {
-                case 191:
-                    var key = '?';
-                    break;
-                default:
-                    var key = String.fromCharCode(ev.keyCode)
+            if (typeof ev.key != 'undefined') {
+                var key = ev.key;
+            } else {
+                switch (ev.keyCode) {
+                    case 191:
+                        var key = '?';
+                        break;
+                    default:
+                        var key = String.fromCharCode(ev.keyCode)
+                }
+            }
+            var key = key.toLowerCase();
+            var ctrl = ev.ctrlKey || ev.metaKey;
+
+            // toggle editor with ctrl-e
+            if (ctrl && key == 'e') {
+                Nengo.ace.toggle_shown();
+                ev.preventDefault();
+            }
+            // undo with ctrl-z
+            if (ctrl && key == 'z') {
+                Nengo.netgraph.notify({ undo: "1" });
+                ev.preventDefault();
+            }
+            // redo with shift-ctrl-z
+            if (ctrl && ev.shiftKey && key == 'z') {
+                Nengo.netgraph.notify({ undo: "0" });
+                ev.preventDefault();
+            }
+            // redo with ctrl-y
+            if (ctrl && key == 'y') {
+                Nengo.netgraph.notify({ undo: "0" });
+                ev.preventDefault();
+            }
+            // run model with spacebar
+            if (key == ' ' && !on_editor) {
+                if (!ev.repeat) {
+                    sim.on_pause_click();
+                }
+                ev.preventDefault();
+            }
+            // bring up help menu with ?
+            if (key == '?' && !on_editor) {
+                self.callMenu();
+                ev.preventDefault();
+            }
+            // bring up minimap with ctrl-m
+            if (ctrl && key == 'm') {
+                Nengo.netgraph.toggleMiniMap();
+                ev.preventDefault();
             }
         }
-        var key = key.toLowerCase();
-        var ctrl = ev.ctrlKey || ev.metaKey;
-
-        // toggle editor with ctrl-e
-        if (ctrl && key == 'e') {
-            Nengo.ace.toggle_shown();
-            ev.preventDefault();
-        }
-        // undo with ctrl-z
-        if (ctrl && key == 'z') {
-            Nengo.netgraph.notify({ undo: "1" });
-            ev.preventDefault();
-        }
-        // redo with shift-ctrl-z
-        if (ctrl && ev.shiftKey && key == 'z') {
-            Nengo.netgraph.notify({ undo: "0" });
-            ev.preventDefault();
-        }
-        // redo with ctrl-y
-        if (ctrl && key == 'y') {
-            Nengo.netgraph.notify({ undo: "0" });
-            ev.preventDefault();
-        }
-        // run model with spacebar
-        if (key == ' ' && !on_editor) {
-            if (!ev.repeat) {
-                sim.on_pause_click();
-            }
-            ev.preventDefault();
-        }
-        // bring up help menu with ?
-        if (key == '?' && !on_editor) {
-            self.callMenu();
-            ev.preventDefault();
-        }
-        // bring up minimap with ctrl-m
-        if (ctrl && key == 'm') {
-            Nengo.netgraph.toggleMiniMap();
-            ev.preventDefault();
-        }
-    }
     });
 }
 
@@ -74,12 +74,7 @@ Nengo.Hotkeys.prototype.callMenu = function () {
 //turn the hotkeys on or off
 Nengo.Hotkeys.prototype.set_active = function(bool) {
     console.assert(typeof(bool) == 'boolean')
-    if (bool == true) {
-        this.active = true;
-    }
-    else {
-        this.active = false;
-    }
+    this.active = bool;
 }
 
 Nengo.hotkeys = new Nengo.Hotkeys();

--- a/nengo_gui/static/hotkeys.js
+++ b/nengo_gui/static/hotkeys.js
@@ -1,7 +1,10 @@
 Nengo.Hotkeys = function () {
     var self = this;
 
+    this.active = true;
+    
     document.addEventListener('keydown', function(ev) {
+    if (self.active) {
 
         var on_editor = (ev.target.className === 'ace_text-input');
 
@@ -56,6 +59,7 @@ Nengo.Hotkeys = function () {
             Nengo.netgraph.toggleMiniMap();
             ev.preventDefault();
         }
+    }
     });
 }
 
@@ -64,6 +68,15 @@ Nengo.Hotkeys.prototype.callMenu = function () {
     Nengo.modal.footer('close');
     Nengo.modal.help_body();
     Nengo.modal.show();
+}
+
+Nengo.Hotkeys.prototype.toggle_hotkeys = function() {
+    if (this.active) {
+        this.active = false;
+    }
+    else {
+        this.active = true;
+    }
 }
 
 Nengo.hotkeys = new Nengo.Hotkeys();

--- a/nengo_gui/static/hotkeys.js
+++ b/nengo_gui/static/hotkeys.js
@@ -69,13 +69,16 @@ Nengo.Hotkeys.prototype.callMenu = function () {
     Nengo.modal.help_body();
     Nengo.modal.show();
 }
-
-Nengo.Hotkeys.prototype.toggle_hotkeys = function() {
-    if (this.active) {
-        this.active = false;
+ 
+//Set active is provided with a boolean argument, which will either
+//turn the hotkeys on or off
+Nengo.Hotkeys.prototype.set_active = function(bool) {
+    console.assert(typeof(bool) == 'boolean')
+    if (bool == true) {
+        this.active = true;
     }
     else {
-        this.active = true;
+        this.active = false;
     }
 }
 

--- a/nengo_gui/static/modal.js
+++ b/nengo_gui/static/modal.js
@@ -11,10 +11,12 @@ Nengo.Modal = function($div) {
         if (self.sim_was_running) {
             sim.play();
         }
+        Nengo.hotkeys.toggle_hotkeys();
     })
 }
 
 Nengo.Modal.prototype.show = function() {
+    Nengo.hotkeys.toggle_hotkeys();
     this.sim_was_running = !sim.paused;
     this.$div.modal('show');
     sim.pause()

--- a/nengo_gui/static/modal.js
+++ b/nengo_gui/static/modal.js
@@ -7,16 +7,17 @@ Nengo.Modal = function($div) {
 
     this.sim_was_running = false;
 
+    //This listener is triggered when the modal is closed
     this.$div.on('hidden.bs.modal', function () {
         if (self.sim_was_running) {
             sim.play();
         }
-        Nengo.hotkeys.toggle_hotkeys();
+        Nengo.hotkeys.set_active(true);
     })
 }
 
 Nengo.Modal.prototype.show = function() {
-    Nengo.hotkeys.toggle_hotkeys();
+    Nengo.hotkeys.set_active(false);
     this.sim_was_running = !sim.paused;
     this.$div.modal('show');
     sim.pause()


### PR DESCRIPTION
Built in a flag to see if the modal is open or not. If it's open, hotkeys are deactivated.
Fixes #385