### PR TITLE
Remove component templates

### DIFF
--- a/nengo_gui/components/__init__.py
+++ b/nengo_gui/components/__init__.py
@@ -1,9 +1,21 @@
-from .slider import Slider, SliderTemplate
-from .value import Value, ValueTemplate
-from .xyvalue import XYValue, XYValueTemplate
-from .sim_control import SimControl, SimControlTemplate
-from .raster import Raster, RasterTemplate
-from .voltage import Voltage, VoltageTemplate
-from .pointer import Pointer, PointerTemplate
-from .netgraph import NetGraph, NetGraphTemplate
-from .ace_editor import AceEditor, AceEditorTemplate
+import inspect
+import sys
+
+from .component import Component
+from .slider import Slider
+from .value import Value
+from .xyvalue import XYValue
+from .sim_control import SimControl
+from .raster import Raster
+from .voltage import Voltage
+from .pointer import Pointer
+from .netgraph import NetGraph
+from .ace_editor import AceEditor
+
+# Old versions of the .cfg files used Templates which had slightly different
+# names than the Components currently usef.  This code is needed to
+# successfully parse those old .cfg files
+this_module = sys.modules[__name__]
+for name, obj in inspect.getmembers(this_module, inspect.isclass):
+    if issubclass(obj, Component):
+        setattr(this_module, name + 'Template', obj)

--- a/nengo_gui/components/__init__.py
+++ b/nengo_gui/components/__init__.py
@@ -1,6 +1,3 @@
-import inspect
-import sys
-
 from .component import Component
 from .slider import Slider
 from .value import Value
@@ -13,9 +10,14 @@ from .netgraph import NetGraph
 from .ace_editor import AceEditor
 
 # Old versions of the .cfg files used Templates which had slightly different
-# names than the Components currently usef.  This code is needed to
+# names than the Components currently use.  This code allows us to
 # successfully parse those old .cfg files
-this_module = sys.modules[__name__]
-for name, obj in inspect.getmembers(this_module, inspect.isclass):
-    if issubclass(obj, Component):
-        setattr(this_module, name + 'Template', obj)
+SliderTemplate = Slider
+ValueTemplate = Value
+XYValueTemplate = XYValue
+SimControlTemplate = SimControl
+RasterTemplate = Raster
+VoltageTemplate = Voltage
+PointerTemplate = Pointer
+NetGraphTemplate = NetGraph
+AceEditorTemplate = AceEditor

--- a/nengo_gui/components/ace_editor.py
+++ b/nengo_gui/components/ace_editor.py
@@ -6,7 +6,7 @@ from nengo_gui.components.component import Component
 import nengo_gui.exec_env
 
 class AceEditor(Component):
-    config_params = {}
+    config_defaults = {}
     def __init__(self):
         # the IPython integration requires this component to be early
         # in the list

--- a/nengo_gui/components/ace_editor.py
+++ b/nengo_gui/components/ace_editor.py
@@ -2,17 +2,20 @@ import json
 
 import nengo
 
-from nengo_gui.components.component import Component, Template
+from nengo_gui.components.component import Component
 import nengo_gui.exec_env
 
 class AceEditor(Component):
-    def __init__(self, page, config, uid):
+    config_params = {}
+    def __init__(self):
         # the IPython integration requires this component to be early
         # in the list
-        super(AceEditor, self).__init__(page, config, uid, component_order=-8)
-        self.uid = uid
-        if self.page.gui.interactive:
-            self.current_code = self.page.code
+        super(AceEditor, self).__init__(component_order=-8)
+
+    def initialize(self, page, config, uid):
+        super(AceEditor, self).initialize(page, config, uid)
+        if page.gui.interactive:
+            self.current_code = page.code
             self.serve_code = True
             self.last_error = None
             self.last_stdout = None
@@ -48,7 +51,7 @@ class AceEditor(Component):
 
     def javascript(self):
         args = json.dumps(dict(active=self.page.gui.interactive))
-        return 'ace_editor = new Nengo.Ace("%s", %s)' % (self.uid, args)
+        return 'ace_editor = new Nengo.Ace("%s", %s)' % (id(self), args)
 
     def message(self, msg):
         if not self.page.gui.interactive:
@@ -67,7 +70,4 @@ class AceEditor(Component):
         else:
             self.page.net_graph.update_code(self.current_code)
 
-
-class AceEditorTemplate(Template):
-    cls = AceEditor
-    config_params = {}
+AceEditorTemplate = AceEditor

--- a/nengo_gui/components/ace_editor.py
+++ b/nengo_gui/components/ace_editor.py
@@ -12,8 +12,8 @@ class AceEditor(Component):
         # in the list
         super(AceEditor, self).__init__(component_order=-8)
 
-    def initialize(self, page, config, uid):
-        super(AceEditor, self).initialize(page, config, uid)
+    def attach(self, page, config, uid):
+        super(AceEditor, self).attach(page, config, uid)
         if page.gui.interactive:
             self.current_code = page.code
             self.serve_code = True

--- a/nengo_gui/components/ace_editor.py
+++ b/nengo_gui/components/ace_editor.py
@@ -69,5 +69,3 @@ class AceEditor(Component):
                 self.page.net_graph.update_code(self.current_code)
         else:
             self.page.net_graph.update_code(self.current_code)
-
-AceEditorTemplate = AceEditor

--- a/nengo_gui/components/action.py
+++ b/nengo_gui/components/action.py
@@ -67,7 +67,6 @@ class ConfigAction(Action):
             setattr(self.page.config[self.component], k, v)
         self.net_graph.modified_config()
         self.send("config", config=cfg)
-        print 'config', self.component.uid, cfg
 
     def apply(self):
         self.load(self.new_cfg)
@@ -164,7 +163,7 @@ class CreateGraph(Action):
         self.act_create_graph()
 
     def undo(self):
-        self.send('delete_graph', uid=self.graph_uid)
+        self.send('delete_graph', uid=id(self.component))
         if self.duplicate is not None:
             self.duplicate.undo()
 

--- a/nengo_gui/components/action.py
+++ b/nengo_gui/components/action.py
@@ -131,11 +131,12 @@ class CreateGraph(Action):
         self.duplicate = None
 
         # Remove any existing sliders associated with the same node
-        for component in self.net_graph.page.components:
-            if (isinstance(component, nengo_gui.components.slider.Slider)
-                    and component.node is self.obj):
-                self.duplicate = RemoveGraph(net_graph, component)
-                self.send('delete_graph', uid=id(component))
+        if type == 'Slider':
+            for component in self.net_graph.page.components:
+                if (isinstance(component, nengo_gui.components.slider.Slider)
+                        and component.node is self.obj):
+                    self.duplicate = RemoveGraph(net_graph, component)
+                    self.send('delete_graph', uid=id(component))
 
         self.act_create_graph()
 

--- a/nengo_gui/components/action.py
+++ b/nengo_gui/components/action.py
@@ -107,13 +107,13 @@ class RemoveGraph(Action):
 
     def undo(self):
         page = self.net_graph.page
-        component = page.add_component(self.component)
+        page.add_component(self.component)
 
-        page.locals[self.uid] = component
-        page.default_labels[component] = self.uid
+        page.locals[self.uid] = self.component
+        page.default_labels[self.component] = self.uid
 
         page.changed = True
-        self.send('js', code=component.javascript())
+        self.send('js', code=self.component.javascript())
 
 
 class CreateGraph(Action):
@@ -153,9 +153,9 @@ class CreateGraph(Action):
         self.net_graph.page.config[self.component].height = self.height
         self.net_graph.modified_config()
 
-        c = self.net_graph.page.add_component(self.component)
+        self.net_graph.page.add_component(self.component)
         self.net_graph.page.changed = True
-        self.send('js', code=c.javascript())
+        self.send('js', code=self.component.javascript())
 
     def apply(self):
         if self.duplicate is not None:

--- a/nengo_gui/components/action.py
+++ b/nengo_gui/components/action.py
@@ -109,8 +109,8 @@ class RemoveGraph(Action):
         page = self.net_graph.page
         page.add_component(self.component)
 
-        page.locals[self.uid] = self.component
-        page.default_labels[self.component] = self.uid
+        page.locals[self.component.uid] = self.component
+        page.default_labels[self.component] = self.component.uid
 
         page.changed = True
         self.send('js', code=self.component.javascript())

--- a/nengo_gui/components/action.py
+++ b/nengo_gui/components/action.py
@@ -64,7 +64,7 @@ class ConfigAction(Action):
 
     def load(self, cfg):
         for k, v in iteritems(cfg):
-            setattr(self.page.config[self.component.template], k, v)
+            setattr(self.page.config[self.component], k, v)
         self.net_graph.modified_config()
         self.send("config", config=cfg)
 
@@ -107,10 +107,10 @@ class RemoveGraph(Action):
 
     def undo(self):
         page = self.net_graph.page
-        component = page.add_template(self.component.template)
+        component = page.add_component(self.component)
 
-        page.locals[self.uid] = component.template
-        page.default_labels[component.template] = self.uid
+        page.locals[self.uid] = component
+        page.default_labels[component] = self.uid
 
         page.changed = True
         self.send('js', code=component.javascript())
@@ -123,8 +123,8 @@ class CreateGraph(Action):
         self.type = type
         self.x, self.y = x, y
         self.width, self.height = width, height
-        cls = getattr(nengo_gui.components, self.type + 'Template')
-        self.template = cls(self.obj, **kwargs)
+        cls = getattr(nengo_gui.components, self.type)
+        self.component = cls(self.obj, **kwargs)
 
         # If only one instance of the component is allowed, and another had to be
         # destroyed to create this one, keep track of it here so it can be undone
@@ -141,19 +141,19 @@ class CreateGraph(Action):
 
     def act_create_graph(self):
         if self.graph_uid is None:
-            self.net_graph.page.generate_uid(self.template, prefix='_viz_')
-            self.graph_uid = self.net_graph.page.get_uid(self.template)
+            self.net_graph.page.generate_uid(self.component, prefix='_viz_')
+            self.graph_uid = self.net_graph.page.get_uid(self.component)
         else:
-            self.net_graph.page.locals[self.graph_uid] = self.template
-            self.net_graph.page.default_labels[self.template] = (
+            self.net_graph.page.locals[self.graph_uid] = self.component
+            self.net_graph.page.default_labels[self.component] = (
                 self.graph_uid)
-        self.net_graph.page.config[self.template].x = self.x
-        self.net_graph.page.config[self.template].y = self.y
-        self.net_graph.page.config[self.template].width = self.width
-        self.net_graph.page.config[self.template].height = self.height
+        self.net_graph.page.config[self.component].x = self.x
+        self.net_graph.page.config[self.component].y = self.y
+        self.net_graph.page.config[self.component].width = self.width
+        self.net_graph.page.config[self.component].height = self.height
         self.net_graph.modified_config()
 
-        c = self.net_graph.page.add_template(self.template)
+        c = self.net_graph.page.add_component(self.component)
         self.net_graph.page.changed = True
         self.send('js', code=c.javascript())
 

--- a/nengo_gui/components/action.py
+++ b/nengo_gui/components/action.py
@@ -56,7 +56,7 @@ class Action(object):
 
 class ConfigAction(Action):
     def __init__(self, page, component, new_cfg, old_cfg):
-        super(ConfigAction, self).__init__(page.net_graph, component.uid)
+        super(ConfigAction, self).__init__(page.net_graph, id(component))
         self.component = component
         self.page = page
         self.new_cfg = new_cfg
@@ -67,6 +67,7 @@ class ConfigAction(Action):
             setattr(self.page.config[self.component], k, v)
         self.net_graph.modified_config()
         self.send("config", config=cfg)
+        print 'config', self.component.uid, cfg
 
     def apply(self):
         self.load(self.new_cfg)
@@ -99,7 +100,7 @@ class ExpandCollapse(Action):
 
 class RemoveGraph(Action):
     def __init__(self, net_graph, component):
-        super(RemoveGraph, self).__init__(net_graph, component.uid)
+        super(RemoveGraph, self).__init__(net_graph, id(component))
         self.component = component
 
     def apply(self):
@@ -135,7 +136,7 @@ class CreateGraph(Action):
             if (isinstance(component, nengo_gui.components.slider.Slider)
                     and component.node is self.obj):
                 self.duplicate = RemoveGraph(net_graph, component)
-                self.send('delete_graph', uid=component.uid)
+                self.send('delete_graph', uid=id(component))
 
         self.act_create_graph()
 

--- a/nengo_gui/components/component.py
+++ b/nengo_gui/components/component.py
@@ -18,7 +18,7 @@ class Component(object):
 
     # The parameters that will be stored in the .cfg file for this Component
     # Subclasses should override this as needed.
-    config_params = dict(x=0, y=0, width=100, height=100, label_visible=True)
+    config_defaults = dict(x=0, y=0, width=100, height=100, label_visible=True)
 
     def __init__(self, component_order=0):
         # when generating Javascript for all the Components in a Page, they

--- a/nengo_gui/components/component.py
+++ b/nengo_gui/components/component.py
@@ -30,7 +30,7 @@ class Component(object):
         # to swap out the old Component with the new one.
         self.replace_with = None
 
-    def initialize(self, page, config, uid):
+    def attach(self, page, config, uid):
         """Connect the Component to a Page."""
         self.config = config  # the nengo.Config[component] for this component
         self.page = page      # the Page this component is in

--- a/nengo_gui/components/component.py
+++ b/nengo_gui/components/component.py
@@ -1,41 +1,111 @@
 import json
 
 class Component(object):
-    default_params = dict(x=0, y=0, width=100, height=100, label_visible=True)
+    """Abstract handler for a particular Component of the user interface.
+
+    Each part of the user interface has part of the code on the server-side
+    (in Python) and a part on the client-side (in Javascript).  These two sides
+    communicate via WebSockets, and the server-side is always a subclass of
+    Component.
+
+    Each Component can be configured via the nengo.Config system.  Components
+    can add required nengo objects into the model to allow them to gather
+    the required data from the running model.  Communication from server to 
+    client is done via Component.update_client(), which is called regularly
+    by the Server.ws_viz_component handler.  Communication from client to
+    server is via Component.message().
+    """
+
+    # The parameters that will be stored in the .cfg file for this Component
+    # Subclasses should override this as needed.
+    config_params = dict(x=0, y=0, width=100, height=100, label_visible=True)
 
     def __init__(self, component_order=0):
-        # the order this component will be defined in the javascript
+        # when generating Javascript for all the Components in a Page, they
+        # will be sorted by component_order.  This way some Components can
+        # be defined before others.
         self.component_order = component_order
+
+        # If we have reloaded the model (while typing in the editor), we need
+        # to swap out the old Component with the new one.
         self.replace_with = None
 
     def initialize(self, page, config, uid):
-        self.config = config
-        self.page = page
-        self.uid = uid
+        """Connect the Component to a Page."""
+        self.config = config  # the nengo.Config[component] for this component
+        self.page = page      # the Page this component is in
+        self.uid = uid        # The Python string referencing this component
 
     def update_client(self, client):
+        """Send any required information to the client.
+
+        This method is called regularly by Server.ws_viz_component().  You
+        send text data to the client-side via a WebSocket as follows:
+            client.write(data)
+        You send binary data as:
+            client.write(data, binary=True)
+        """
         pass
     def message(self, msg):
+        """Receive data from the client.
+
+        Any data sent by the client ove the WebSocket will be passed into
+        this method.
+        """
         print('unhandled message', msg)
 
     def finish(self):
+        """Close this Component"""
         pass
 
     def add_nengo_objects(self, page):
+        """Add or modify the nengo model before build.
+
+        Components may need to modify the underlying nengo.Network by adding
+        Nodes and Connections or modifying the structure in other ways.
+        This method will be called for all Components just before the build
+        phase.
+        """
         pass
 
     def remove_nengo_objects(self, page):
+        """Undo the effects of add_nengo_objects.
+
+        After the build is complete, remove the changes to the nengo.Network
+        so that it is all set to be built again in the future.
+        """
         pass
 
     def javascript_config(self, cfg):
+        """Convert the nengo.Config information into javascript.
+        
+        This is needed so we can send that config information to the client.
+        """
         for attr in self.config._clsparams.params:
             cfg[attr] = getattr(self.config, attr)
         return json.dumps(cfg)
 
-    def code_python_args(self, uids):
-        return []
-
     def code_python(self, uids):
+        """Generate Python code for this Component.
+
+        This is used in the .cfg file to generate a valid Python expression
+        that re-creates this Component.  
+
+        The input uids is a dictionary from Python objects to strings that
+        refer to those Python objects (the reverse of the locals() dictionary)
+        """
         args = self.code_python_args(uids)
         name = self.__class__.__name__
         return 'nengo_gui.components.%s(%s)' % (name, ','.join(args))
+
+    def code_python_args(self, uids):
+        """Return a list of strings giving the constructor arguments.
+
+        This is used by code_python to re-create the Python string that
+        generated this Component, so it can be saved in the .cfg file.
+
+        The input uids is a dictionary from Python objects to strings that
+        refer to those Python objects (the reverse of the locals() dictionary)
+        """
+        return []
+

--- a/nengo_gui/components/component.py
+++ b/nengo_gui/components/component.py
@@ -1,13 +1,17 @@
 import json
 
 class Component(object):
-    def __init__(self, page, config, uid, component_order=0):
-        self.config = config
-        self.uid = uid
-        self.page = page
+    default_params = dict(x=0, y=0, width=100, height=100, label_visible=True)
+
+    def __init__(self, component_order=0):
         # the order this component will be defined in the javascript
         self.component_order = component_order
         self.replace_with = None
+
+    def initialize(self, page, config, uid):
+        self.config = config
+        self.page = page
+        self.uid = uid
 
     def update_client(self, client):
         pass
@@ -28,22 +32,10 @@ class Component(object):
             cfg[attr] = getattr(self.config, attr)
         return json.dumps(cfg)
 
+    def code_python_args(self, uids):
+        return []
 
-class Template(object):
-    default_params = dict(x=0, y=0, width=100, height=100, label_visible=True)
-    cls = None   # subclasses are expected to set this to be the class of
-                 # the object that should be created.
-
-    def __init__(self, *args, **kwargs):
-        self.args = args
-        self.kwargs = kwargs
-    def create(self, page):
-        uid = '_uid_%d' % id(self)
-        c = self.cls(page, page.config[self], uid,
-                     *self.args, **self.kwargs)
-        c.template = self
-        return c
     def code_python(self, uids):
-        args = [uids[x] for x in self.args]
+        args = self.code_python_args(uids)
         name = self.__class__.__name__
         return 'nengo_gui.components.%s(%s)' % (name, ','.join(args))

--- a/nengo_gui/components/netgraph.py
+++ b/nengo_gui/components/netgraph.py
@@ -468,5 +468,3 @@ class NetGraph(Component):
         posts = self.get_parents(post)[:-1]
         info = dict(uid=uid, pre=pres, post=posts, type='conn', parent=parent)
         client.write(json.dumps(info))
-
-NetGraphTemplate = NetGraph

--- a/nengo_gui/components/netgraph.py
+++ b/nengo_gui/components/netgraph.py
@@ -166,7 +166,7 @@ class NetGraph(Component):
                 if item in removed_items:
                     self.to_be_sent.append(dict(type='delete_graph',
                                                 uid=id(c),
-                                                report_back=False))
+                                                notify_server=False))
                     orphan_components.append(c)
                     break
 

--- a/nengo_gui/components/netgraph.py
+++ b/nengo_gui/components/netgraph.py
@@ -32,8 +32,8 @@ class NetGraph(Component):
         self.parents = {}
         self.initialized_pan_and_zoom = False
 
-    def initialize(self, page, config, uid):
-        super(NetGraph, self).initialize(page, config, uid)
+    def attach(self, page, config, uid):
+        super(NetGraph, self).attach(page, config, uid)
         self.layout = nengo_gui.layout.Layout(self.page.model)
         self.to_be_expanded = collections.deque([self.page.model])
         self.to_be_sent = collections.deque()

--- a/nengo_gui/components/netgraph.py
+++ b/nengo_gui/components/netgraph.py
@@ -15,7 +15,7 @@ from .action import create_action
 
 
 class NetGraph(Component):
-    config_params = {}
+    config_defaults = {}
     configs = {}
 
     def __init__(self):

--- a/nengo_gui/components/pointer.py
+++ b/nengo_gui/components/pointer.py
@@ -10,7 +10,7 @@ from nengo_gui.components.component import Component
 
 
 class Pointer(Component):
-    config_params = dict(show_pairs=False, **Component.config_params)
+    config_defaults = dict(show_pairs=False, **Component.config_defaults)
     def __init__(self, obj, **kwargs):
         super(Pointer, self).__init__()
         self.obj = obj

--- a/nengo_gui/components/pointer.py
+++ b/nengo_gui/components/pointer.py
@@ -74,7 +74,7 @@ class Pointer(Component):
         return 'new Nengo.Pointer(main, sim, %s);' % json
 
     def code_python_args(self, uids):
-        return [uids[self.obj], 'target=%s' % repr(self.target)]
+        return [uids[self.obj], 'target=%r' % self.target]
 
     def message(self, msg):
         if len(msg) == 0:

--- a/nengo_gui/components/pointer.py
+++ b/nengo_gui/components/pointer.py
@@ -74,7 +74,7 @@ class Pointer(Component):
         return 'new Nengo.Pointer(main, sim, %s);' % json
 
     def code_python_args(self, uids):
-        return [uids[self.obj], 'target=%s' % self.target]
+        return [uids[self.obj], 'target=%s' % repr(self.target)]
 
     def message(self, msg):
         if len(msg) == 0:

--- a/nengo_gui/components/pointer.py
+++ b/nengo_gui/components/pointer.py
@@ -20,8 +20,8 @@ class Pointer(Component):
         self.vocab_out = obj.outputs[self.target][1]
         self.vocab_in = obj.inputs[self.target][1]
 
-    def initialize(self, page, config, uid):
-        super(Pointer, self).initialize(page, config, uid)
+    def attach(self, page, config, uid):
+        super(Pointer, self).attach(page, config, uid)
         self.label = page.get_label(self.obj)
         self.vocab_out.include_pairs = config.show_pairs
 

--- a/nengo_gui/components/pointer.py
+++ b/nengo_gui/components/pointer.py
@@ -14,12 +14,15 @@ class Pointer(Component):
     def __init__(self, obj, **kwargs):
         super(Pointer, self).__init__()
         self.obj = obj
-        self.label = page.get_label(obj)
         self.data = collections.deque()
         self.override_target = None
         self.target = kwargs.get('args', 'default')
         self.vocab_out = obj.outputs[self.target][1]
         self.vocab_in = obj.inputs[self.target][1]
+
+    def initialize(self, page, config, uid):
+        super(Pointer, self).initialize(page, config, uid)
+        self.label = page.get_label(self.obj)
         self.vocab_out.include_pairs = config.show_pairs
 
     def add_nengo_objects(self, page):

--- a/nengo_gui/components/pointer.py
+++ b/nengo_gui/components/pointer.py
@@ -6,12 +6,13 @@ import nengo.spa
 from nengo.spa.module import Module
 import numpy as np
 
-from nengo_gui.components.component import Component, Template
+from nengo_gui.components.component import Component
 
 
 class Pointer(Component):
-    def __init__(self, page, config, uid, obj, **kwargs):
-        super(Pointer, self).__init__(page, config, uid)
+    config_params = dict(show_pairs=False, **Component.default_params)
+    def __init__(self, obj, **kwargs):
+        super(Pointer, self).__init__()
         self.obj = obj
         self.label = page.get_label(obj)
         self.data = collections.deque()
@@ -65,9 +66,12 @@ class Pointer(Component):
             client.write(data, binary=False)
 
     def javascript(self):
-        info = dict(uid=self.uid, label=self.label)
+        info = dict(uid=id(self), label=self.label)
         json = self.javascript_config(info)
         return 'new Nengo.Pointer(main, sim, %s);' % json
+
+    def code_python_args(self, uids):
+        return [uids[self.obj], 'target=%s' % self.target]
 
     def message(self, msg):
         if len(msg) == 0:
@@ -85,7 +89,4 @@ class Pointer(Component):
         else:
             return []
 
-
-class PointerTemplate(Template):
-    cls = Pointer
-    config_params = dict(show_pairs=False, **Template.default_params)
+PointerTemplate = Pointer

--- a/nengo_gui/components/pointer.py
+++ b/nengo_gui/components/pointer.py
@@ -10,7 +10,7 @@ from nengo_gui.components.component import Component
 
 
 class Pointer(Component):
-    config_params = dict(show_pairs=False, **Component.default_params)
+    config_params = dict(show_pairs=False, **Component.config_params)
     def __init__(self, obj, **kwargs):
         super(Pointer, self).__init__()
         self.obj = obj
@@ -91,5 +91,3 @@ class Pointer(Component):
             return list(obj.outputs.keys())
         else:
             return []
-
-PointerTemplate = Pointer

--- a/nengo_gui/components/raster.py
+++ b/nengo_gui/components/raster.py
@@ -19,8 +19,8 @@ class Raster(Component):
             n_neurons = min(self.max_neurons, 10)
         self.n_neurons = n_neurons
 
-    def initialize(self, page, config, uid):
-        super(Raster, self).initialize(page, config, uid)
+    def attach(self, page, config, uid):
+        super(Raster, self).attach(page, config, uid)
         self.label = page.get_label(self.obj.ensemble)
 
     def add_nengo_objects(self, page):

--- a/nengo_gui/components/raster.py
+++ b/nengo_gui/components/raster.py
@@ -4,12 +4,13 @@ import collections
 import nengo
 import numpy as np
 
-from nengo_gui.components.component import Component, Template
+from nengo_gui.components.component import Component
 
 
 class Raster(Component):
-    def __init__(self, page, config, uid, obj, n_neurons=None):
-        super(Raster, self).__init__(page, config, uid)
+    config_params = dict(**Component.default_params)
+    def __init__(self, obj, n_neurons=None):
+        super(Raster, self).__init__()
         self.neuron_type = obj.neuron_type
         self.obj = obj.neurons
         self.data = collections.deque()
@@ -41,12 +42,12 @@ class Raster(Component):
             client.write(data, binary=True)
 
     def javascript(self):
-        info = dict(uid=self.uid, n_neurons=self.n_neurons, label=self.label,
+        info = dict(uid=id(self), n_neurons=self.n_neurons, label=self.label,
                     max_neurons=self.max_neurons)
         json = self.javascript_config(info)
         return 'new Nengo.Raster(main, sim, %s);' % json
 
+    def code_python_args(self, uids):
+        return [uids[self.obj]]
 
-class RasterTemplate(Template):
-    cls = Raster
-    config_params = dict(**Template.default_params)
+RasterTemplate = Raster

--- a/nengo_gui/components/raster.py
+++ b/nengo_gui/components/raster.py
@@ -8,7 +8,7 @@ from nengo_gui.components.component import Component
 
 
 class Raster(Component):
-    config_params = dict(**Component.config_params)
+    config_defaults = dict(**Component.config_defaults)
     def __init__(self, obj, n_neurons=None):
         super(Raster, self).__init__()
         self.neuron_type = obj.neuron_type

--- a/nengo_gui/components/raster.py
+++ b/nengo_gui/components/raster.py
@@ -8,7 +8,7 @@ from nengo_gui.components.component import Component
 
 
 class Raster(Component):
-    config_params = dict(**Component.default_params)
+    config_params = dict(**Component.config_params)
     def __init__(self, obj, n_neurons=None):
         super(Raster, self).__init__()
         self.neuron_type = obj.neuron_type
@@ -52,5 +52,3 @@ class Raster(Component):
 
     def code_python_args(self, uids):
         return [uids[self.obj.ensemble]]
-
-RasterTemplate = Raster

--- a/nengo_gui/components/raster.py
+++ b/nengo_gui/components/raster.py
@@ -14,11 +14,14 @@ class Raster(Component):
         self.neuron_type = obj.neuron_type
         self.obj = obj.neurons
         self.data = collections.deque()
-        self.label = page.get_label(obj)
         self.max_neurons = obj.n_neurons
         if n_neurons is None:
             n_neurons = min(self.max_neurons, 10)
         self.n_neurons = n_neurons
+
+    def initialize(self, page, config, uid):
+        super(Raster, self).initialize(page, config, uid)
+        self.label = page.get_label(self.obj.ensemble)
 
     def add_nengo_objects(self, page):
         with page.model:
@@ -48,6 +51,6 @@ class Raster(Component):
         return 'new Nengo.Raster(main, sim, %s);' % json
 
     def code_python_args(self, uids):
-        return [uids[self.obj]]
+        return [uids[self.obj.ensemble]]
 
 RasterTemplate = Raster

--- a/nengo_gui/components/sim_control.py
+++ b/nengo_gui/components/sim_control.py
@@ -12,7 +12,7 @@ from nengo_gui.components.component import Component
 import nengo_gui.exec_env
 
 class SimControl(Component):
-    config_params = dict(shown_time=0.5, kept_time=4.0)
+    config_defaults = dict(shown_time=0.5, kept_time=4.0)
     def __init__(self, dt=0.001):
         # this component must be the very first one defined, so
         # its component_order is the smallest overall

--- a/nengo_gui/components/sim_control.py
+++ b/nengo_gui/components/sim_control.py
@@ -8,28 +8,33 @@ import os
 import os.path
 import json
 
-from nengo_gui.components.component import Component, Template
+from nengo_gui.components.component import Component
 import nengo_gui.exec_env
 
 class SimControl(Component):
-    def __init__(self, page, config, uid, dt=0.001):
+    config_params = dict(shown_time=0.5, kept_time=4.0)
+    def __init__(self, dt=0.001):
         # this component must be the very first one defined, so
         # its component_order is the smallest overall
-        super(SimControl, self).__init__(page, config, uid, component_order=-10)
+        super(SimControl, self).__init__(component_order=-10)
         self.paused = True
         self.last_tick = None
         self.rate = 0.0
         self.model_dt = dt
         self.rate_tau = 1.0
         self.last_send_rate = None
-        self.shown_time = config.shown_time
-        self.kept_time = config.kept_time
         self.sim_ticks = 0
         self.skipped = 1
         self.time = 0.0
         self.last_status = None
         self.next_ping_time = None
         self.send_config_options = False
+
+    def initialize(self, page, config, uid):
+        super(SimControl, self).initialize(page, config, uid)
+        self.shown_time = config.shown_time
+        self.kept_time = config.kept_time
+
 
     def add_nengo_objects(self, page):
         with page.model:
@@ -99,7 +104,7 @@ class SimControl(Component):
             return 'running'
 
     def javascript(self):
-        info = dict(uid=self.uid)
+        info = dict(uid=id(self))
         fn = json.dumps(self.page.filename)
         js = self.javascript_config(info)
         return ('sim = new Nengo.SimControl(control, %s);\n'
@@ -131,7 +136,4 @@ class SimControl(Component):
             items.append(item)
         return ''.join(items)
 
-
-class SimControlTemplate(Template):
-    cls = SimControl
-    config_params = dict(shown_time=0.5, kept_time=4.0)
+SimControlTemplate = SimControl

--- a/nengo_gui/components/sim_control.py
+++ b/nengo_gui/components/sim_control.py
@@ -135,5 +135,3 @@ class SimControl(Component):
             item = '<option %s>%s</option>' % (selected, module)
             items.append(item)
         return ''.join(items)
-
-SimControlTemplate = SimControl

--- a/nengo_gui/components/sim_control.py
+++ b/nengo_gui/components/sim_control.py
@@ -30,8 +30,8 @@ class SimControl(Component):
         self.next_ping_time = None
         self.send_config_options = False
 
-    def initialize(self, page, config, uid):
-        super(SimControl, self).initialize(page, config, uid)
+    def attach(self, page, config, uid):
+        super(SimControl, self).attach(page, config, uid)
         self.shown_time = config.shown_time
         self.kept_time = config.kept_time
 

--- a/nengo_gui/components/slider.py
+++ b/nengo_gui/components/slider.py
@@ -21,8 +21,8 @@ class Slider(Component):
         if not callable(self.base_output):
             self.start_value[:] = self.base_output
 
-    def initialize(self, page, config, uid):
-        super(Slider, self).initialize(page, config, uid)
+    def attach(self, page, config, uid):
+        super(Slider, self).attach(page, config, uid)
         self.label = page.get_label(self.node)
 
     def add_nengo_objects(self, page):

--- a/nengo_gui/components/slider.py
+++ b/nengo_gui/components/slider.py
@@ -5,7 +5,9 @@ import collections
 from nengo_gui.components.component import Component
 
 class Slider(Component):
-    config_params = dict(max_value=1, min_value=-1, **Component.config_params)
+    config_defaults = dict(max_value=1, min_value=-1, 
+                           **Component.config_defaults)
+
     def __init__(self, node):
         super(Slider, self).__init__()
         self.node = node

--- a/nengo_gui/components/slider.py
+++ b/nengo_gui/components/slider.py
@@ -5,7 +5,7 @@ import collections
 from nengo_gui.components.component import Component
 
 class Slider(Component):
-    config_params = dict(max_value=1, min_value=-1, **Component.default_params)
+    config_params = dict(max_value=1, min_value=-1, **Component.config_params)
     def __init__(self, node):
         super(Slider, self).__init__()
         self.node = node
@@ -68,5 +68,3 @@ class Slider(Component):
 
     def code_python_args(self, uids):
         return [uids[self.node]]
-
-SliderTemplate = Slider

--- a/nengo_gui/components/slider.py
+++ b/nengo_gui/components/slider.py
@@ -2,22 +2,26 @@ import numpy as np
 import struct
 import collections
 
-from nengo_gui.components.component import Component, Template
+from nengo_gui.components.component import Component
 
 class Slider(Component):
-    def __init__(self, page, config, uid, node):
-        super(Slider, self).__init__(page, config, uid)
+    config_params = dict(max_value=1, min_value=-1, **Component.default_params)
+    def __init__(self, node):
+        super(Slider, self).__init__()
         self.node = node
         self.base_output = node.output
         self.override = [None] * node.size_out
         self.last_time = None
         self.value = np.zeros(node.size_out)
-        self.label = page.get_label(node)
         self.start_value = np.zeros(node.size_out, dtype=float)
         self.struct = struct.Struct('<%df' % (1 + node.size_out))
         self.data = collections.deque()
         if not callable(self.base_output):
             self.start_value[:] = self.base_output
+
+    def initialize(self, page, config, uid):
+        super(Slider, self).initialize(page, config, uid)
+        self.label = page.get_label(self.node)
 
     def add_nengo_objects(self, page):
         self.node.output = self.override_output
@@ -41,7 +45,7 @@ class Slider(Component):
         return self.value
 
     def javascript(self):
-        info = dict(uid=self.uid, n_sliders=len(self.override),
+        info = dict(uid=id(self), n_sliders=len(self.override),
                     label=self.label,
                     start_value=[float(x) for x in self.start_value])
         json = self.javascript_config(info)
@@ -62,6 +66,7 @@ class Slider(Component):
             value = float(value)
             self.override[index] = value
 
-class SliderTemplate(Template):
-    cls = Slider
-    config_params = dict(max_value=1, min_value=-1, **Template.default_params)
+    def code_python_args(self, uids):
+        return [uids[self.node]]
+
+SliderTemplate = Slider

--- a/nengo_gui/components/value.py
+++ b/nengo_gui/components/value.py
@@ -31,8 +31,8 @@ class Value(Component):
         # being the vector values, one per dimension.
         self.struct = struct.Struct('<%df' % (1 + self.n_lines))
 
-    def initialize(self, page, config, uid):
-        super(Value, self).initialize(page, config, uid)
+    def attach(self, page, config, uid):
+        super(Value, self).attach(page, config, uid)
         # use the label of the object being plotted as our label
         self.label = page.get_label(self.obj)
 

--- a/nengo_gui/components/value.py
+++ b/nengo_gui/components/value.py
@@ -10,7 +10,7 @@ from nengo_gui.components.component import Component
 class Value(Component):
     config_params = dict(max_value=1,
                          min_value=-1, 
-                         **Component.default_params)
+                         **Component.config_params)
     def __init__(self, obj):
         super(Value, self).__init__()
         self.obj = obj
@@ -48,5 +48,3 @@ class Value(Component):
 
     def code_python_args(self, uids):
         return [uids[self.obj]]
-
-ValueTemplate = Value

--- a/nengo_gui/components/value.py
+++ b/nengo_gui/components/value.py
@@ -8,43 +8,68 @@ from nengo_gui.components.component import Component
 
 
 class Value(Component):
+    """The server-side system for a Value plot."""
+
+    # the parameters to be stored in the .cfg file
     config_params = dict(max_value=1,
                          min_value=-1, 
                          **Component.config_params)
+
     def __init__(self, obj):
         super(Value, self).__init__()
+        # the object whose decoded value should be displayed
         self.obj = obj
+
+        # the pending data to be sent to the client
         self.data = collections.deque()
+
+        # the number of data values to send
         self.n_lines = int(obj.size_out)
+
+        # the binary data format to sent in.  In this case, it is a list of
+        # floats, with the first float being the time stamp and the rest
+        # being the vector values, one per dimension.
         self.struct = struct.Struct('<%df' % (1 + self.n_lines))
 
     def initialize(self, page, config, uid):
         super(Value, self).initialize(page, config, uid)
+        # use the label of the object being plotted as our label
         self.label = page.get_label(self.obj)
 
     def add_nengo_objects(self, page):
+        # create a Node and a Connection so the Node will be given the
+        # data we want to show while the model is running.
         with page.model:
             self.node = nengo.Node(self.gather_data,
                                    size_in=self.obj.size_out)
             self.conn = nengo.Connection(self.obj, self.node, synapse=0.01)
 
     def remove_nengo_objects(self, page):
+        # undo the changes made by add_nengo_objects
         page.model.connections.remove(self.conn)
         page.model.nodes.remove(self.node)
 
     def gather_data(self, t, x):
+        # This is the Node function for the Node created in add_nengo_objects
+        # It will be called by the running model, and will store the data
+        # that should be sent to the client
         self.data.append(self.struct.pack(t, *x))
 
     def update_client(self, client):
+        # while there is data that should be sent to the client
         while len(self.data) > 0:
             item = self.data.popleft()
+            # send the data to the client
             client.write(item, binary=True)
 
     def javascript(self):
+        # generate the javascript that will create the client-side object
         info = dict(uid=id(self), label=self.label,
                     n_lines=self.n_lines, synapse=0)
         json = self.javascript_config(info)
         return 'new Nengo.Value(main, sim, %s);' % json
 
     def code_python_args(self, uids):
+        # generate the list of strings for the .cfg file to save this Component
+        # (this is the text that would be passed in to the constructor)
         return [uids[self.obj]]

--- a/nengo_gui/components/value.py
+++ b/nengo_gui/components/value.py
@@ -11,9 +11,9 @@ class Value(Component):
     """The server-side system for a Value plot."""
 
     # the parameters to be stored in the .cfg file
-    config_params = dict(max_value=1,
+    config_defaults = dict(max_value=1,
                          min_value=-1, 
-                         **Component.config_params)
+                         **Component.config_defaults)
 
     def __init__(self, obj):
         super(Value, self).__init__()

--- a/nengo_gui/components/voltage.py
+++ b/nengo_gui/components/voltage.py
@@ -9,7 +9,7 @@ from nengo_gui.components.component import Component
 
 class Voltage(Component):
     config_params = dict(
-        max_value=5.0, min_value=0.0, **Component.default_params)
+        max_value=5.0, min_value=0.0, **Component.config_params)
     def __init__(self, obj, n_neurons=5):
         super(Voltage, self).__init__()
         self.obj = obj.neurons
@@ -57,4 +57,3 @@ class Voltage(Component):
 
     def code_python_args(self, uids):
         return [uids[self.obj.ensemble]]
-VoltageTemplate = Voltage

--- a/nengo_gui/components/voltage.py
+++ b/nengo_gui/components/voltage.py
@@ -4,12 +4,14 @@ import nengo
 import numpy as np
 import struct
 
-from nengo_gui.components.component import Component, Template
+from nengo_gui.components.component import Component
 
 
 class Voltage(Component):
-    def __init__(self, page, config, uid, obj, n_neurons=5):
-        super(Voltage, self).__init__(page, config, uid)
+    config_params = dict(
+        max_value=5.0, min_value=0.0, **Component.default_params)
+    def __init__(self, obj, n_neurons=5):
+        super(Voltage, self).__init__()
         self.obj = obj.neurons
         self.data = []
         self.label = page.get_label(obj)
@@ -45,13 +47,11 @@ class Voltage(Component):
             client.write(packet, binary=True)
 
     def javascript(self):
-        info = dict(uid=self.uid, label=self.label,
+        info = dict(uid=id(self), label=self.label,
                     n_lines=self.n_neurons, synapse=0)
         json = self.javascript_config(info)
         return 'new Nengo.Value(main, sim, %s);' % json
 
-
-class VoltageTemplate(Template):
-    cls = Voltage
-    config_params = dict(
-        max_value=5.0, min_value=0.0, **Template.default_params)
+    def code_python_args(self, uids):
+        return [uids[self.obj.ensemble]]
+VoltageTemplate = Voltage

--- a/nengo_gui/components/voltage.py
+++ b/nengo_gui/components/voltage.py
@@ -8,8 +8,8 @@ from nengo_gui.components.component import Component
 
 
 class Voltage(Component):
-    config_params = dict(
-        max_value=5.0, min_value=0.0, **Component.config_params)
+    config_defaults = dict(
+        max_value=5.0, min_value=0.0, **Component.config_defaults)
     def __init__(self, obj, n_neurons=5):
         super(Voltage, self).__init__()
         self.obj = obj.neurons

--- a/nengo_gui/components/voltage.py
+++ b/nengo_gui/components/voltage.py
@@ -18,8 +18,8 @@ class Voltage(Component):
         self.n_neurons = min(n_neurons, self.max_neurons)
         self.struct = struct.Struct('<%df' % (1 + self.n_neurons))
 
-    def initialize(self, page, config, uid):
-        super(Voltage, self).initialize(page, config, uid)
+    def attach(self, page, config, uid):
+        super(Voltage, self).attach(page, config, uid)
         self.label = page.get_label(self.obj.ensemble)
 
     def add_nengo_objects(self, page):

--- a/nengo_gui/components/voltage.py
+++ b/nengo_gui/components/voltage.py
@@ -14,10 +14,13 @@ class Voltage(Component):
         super(Voltage, self).__init__()
         self.obj = obj.neurons
         self.data = []
-        self.label = page.get_label(obj)
         self.max_neurons = int(self.obj.size_out)
         self.n_neurons = min(n_neurons, self.max_neurons)
         self.struct = struct.Struct('<%df' % (1 + self.n_neurons))
+
+    def initialize(self, page, config, uid):
+        super(Voltage, self).initialize(page, config, uid)
+        self.label = page.get_label(self.obj.ensemble)
 
     def add_nengo_objects(self, page):
         with page.model:

--- a/nengo_gui/components/xyvalue.py
+++ b/nengo_gui/components/xyvalue.py
@@ -13,10 +13,13 @@ class XYValue(Component):
     def __init__(self, obj):
         super(XYValue, self).__init__()
         self.obj = obj
-        self.label = page.get_label(obj)
         self.data = collections.deque()
         self.n_lines = int(obj.size_out)
         self.struct = struct.Struct('<%df' % (1 + self.n_lines))
+
+    def initialize(self, page, config, uid):
+        super(XYValue, self).initialize(page, config, uid)
+        self.label = page.get_label(self.obj)
 
     def add_nengo_objects(self, page):
         with page.model:

--- a/nengo_gui/components/xyvalue.py
+++ b/nengo_gui/components/xyvalue.py
@@ -17,8 +17,8 @@ class XYValue(Component):
         self.n_lines = int(obj.size_out)
         self.struct = struct.Struct('<%df' % (1 + self.n_lines))
 
-    def initialize(self, page, config, uid):
-        super(XYValue, self).initialize(page, config, uid)
+    def attach(self, page, config, uid):
+        super(XYValue, self).attach(page, config, uid)
         self.label = page.get_label(self.obj)
 
     def add_nengo_objects(self, page):

--- a/nengo_gui/components/xyvalue.py
+++ b/nengo_gui/components/xyvalue.py
@@ -4,12 +4,14 @@ import collections
 import nengo
 import numpy as np
 
-from nengo_gui.components.component import Component, Template
+from nengo_gui.components.component import Component
 
 
 class XYValue(Component):
-    def __init__(self, page, config, uid, obj):
-        super(XYValue, self).__init__(page, config, uid)
+    config_params = dict(max_value=1, min_value=-1, index_x=0, index_y=1,
+                         **Component.default_params)
+    def __init__(self, obj):
+        super(XYValue, self).__init__()
         self.obj = obj
         self.label = page.get_label(obj)
         self.data = collections.deque()
@@ -35,11 +37,11 @@ class XYValue(Component):
             client.write(data, binary=True)
 
     def javascript(self):
-        info = dict(uid=self.uid, n_lines=self.n_lines, label=self.label)
+        info = dict(uid=id(self), n_lines=self.n_lines, label=self.label)
         json = self.javascript_config(info)
         return 'new Nengo.XYValue(main, sim, %s);' % json
 
-class XYValueTemplate(Template):
-    cls = XYValue
-    config_params = dict(max_value=1, min_value=-1, index_x=0, index_y=1,
-                         **Template.default_params)
+    def code_python_args(self, uids):
+        return [uids[self.obj]]
+
+XYValueTemplate = XYValue

--- a/nengo_gui/components/xyvalue.py
+++ b/nengo_gui/components/xyvalue.py
@@ -9,7 +9,7 @@ from nengo_gui.components.component import Component
 
 class XYValue(Component):
     config_params = dict(max_value=1, min_value=-1, index_x=0, index_y=1,
-                         **Component.default_params)
+                         **Component.config_params)
     def __init__(self, obj):
         super(XYValue, self).__init__()
         self.obj = obj
@@ -46,5 +46,3 @@ class XYValue(Component):
 
     def code_python_args(self, uids):
         return [uids[self.obj]]
-
-XYValueTemplate = XYValue

--- a/nengo_gui/components/xyvalue.py
+++ b/nengo_gui/components/xyvalue.py
@@ -8,8 +8,8 @@ from nengo_gui.components.component import Component
 
 
 class XYValue(Component):
-    config_params = dict(max_value=1, min_value=-1, index_x=0, index_y=1,
-                         **Component.config_params)
+    config_defaults = dict(max_value=1, min_value=-1, index_x=0, index_y=1,
+                           **Component.config_defaults)
     def __init__(self, obj):
         super(XYValue, self).__init__()
         self.obj = obj

--- a/nengo_gui/config.py
+++ b/nengo_gui/config.py
@@ -47,6 +47,10 @@ class Config(nengo.Config):
                 lines.append('%s = %s' % (uid, obj.code_python(uids)))
                 for k in obj.config_params.keys():
                     v = getattr(self[obj], k)
-                    lines.append('_viz_config[%s].%s = %g' % (uid, k, v))
+                    if isinstance(v, bool):
+                        val = '%s' % v
+                    else:
+                        val = '%g' % v
+                    lines.append('_viz_config[%s].%s = %s' % (uid, k, val))
 
         return '\n'.join(lines)

--- a/nengo_gui/config.py
+++ b/nengo_gui/config.py
@@ -22,8 +22,8 @@ class Config(nengo.Config):
 
         for clsname, cls in inspect.getmembers(nengo_gui.components):
             if inspect.isclass(cls):
-                if issubclass(cls, nengo_gui.components.component.Template):
-                    if cls != nengo_gui.components.component.Template:
+                if issubclass(cls, nengo_gui.components.component.Component):
+                    if cls != nengo_gui.components.component.Component:
                         self.configures(cls)
                         for k, v in cls.config_params.items():
                             self[cls].set_param(k, nengo.params.Parameter(v))
@@ -43,7 +43,7 @@ class Config(nengo.Config):
                                  % (uid, self[obj].expanded))
                     lines.append('_viz_config[%s].has_layout=%s'
                                  % (uid, self[obj].has_layout))
-            elif isinstance(obj, nengo_gui.components.component.Template):
+            elif isinstance(obj, nengo_gui.components.component.Component):
                 lines.append('%s = %s' % (uid, obj.code_python(uids)))
                 for k in obj.config_params.keys():
                     v = getattr(self[obj], k)

--- a/nengo_gui/config.py
+++ b/nengo_gui/config.py
@@ -25,7 +25,7 @@ class Config(nengo.Config):
                 if issubclass(cls, nengo_gui.components.component.Component):
                     if cls != nengo_gui.components.component.Component:
                         self.configures(cls)
-                        for k, v in cls.config_params.items():
+                        for k, v in cls.config_defaults.items():
                             self[cls].set_param(k, nengo.params.Parameter(v))
 
     def dumps(self, uids):
@@ -45,7 +45,7 @@ class Config(nengo.Config):
                                  % (uid, self[obj].has_layout))
             elif isinstance(obj, nengo_gui.components.component.Component):
                 lines.append('%s = %s' % (uid, obj.code_python(uids)))
-                for k in obj.config_params.keys():
+                for k in obj.config_defaults.keys():
                     v = getattr(self[obj], k)
                     if isinstance(v, bool):
                         val = '%s' % v

--- a/nengo_gui/page.py
+++ b/nengo_gui/page.py
@@ -166,12 +166,10 @@ class Page(object):
 
     def add_component(self, component):
         """Add a new Component to an existing Page."""
-        #TODO: do we need to return anything here? make a uid?
         self.gui.component_uids[id(component)] = component
         uid = self.get_uid(component)
         component.initialize(self, self.config[component], uid=uid)
         self.components.append(component)
-        return component
 
     def execute(self, code):
         """Run the given code to generate self.model and self.locals.

--- a/nengo_gui/page.py
+++ b/nengo_gui/page.py
@@ -156,7 +156,7 @@ class Page(object):
         self.components = []
         self.component_uids = {}
         for k, v in self.locals.items():
-            if isinstance(v, nengo_gui.components.component.Component):
+            if isinstance(v, nengo_gui.components.Component):
                 self.component_uids[v] = k
                 self.gui.component_uids[id(v)] = v
                 self.components.append(v)
@@ -248,7 +248,7 @@ class Page(object):
                 config[self.model].size = (1.0, 1.0)
 
         for k, v in self.locals.items():
-            if isinstance(v, nengo_gui.components.component.Component):
+            if isinstance(v, nengo_gui.components.Component):
                 self.default_labels[v] = k
                 v.initialize(page=self, config=config[v], uid=k)
 

--- a/nengo_gui/page.py
+++ b/nengo_gui/page.py
@@ -56,8 +56,8 @@ class Page(object):
         self.default_labels = None # dict of names to use for unlabelled objs
         self.config = None         # nengo_gui.Config for storing layout
         self.components = None     # list of Components
-        self.uid_prefix_counter = None # used for generating uids for templates
-        self.template_uids = None  # mapping from Templates to text
+        self.uid_prefix_counter = None # used for generating uids for components
+        self.component_uids = None  # mapping from Components to text
 
         self.config_save_needed = False
         self.config_save_time = None   # time of last config file save
@@ -152,26 +152,26 @@ class Page(object):
 
     def create_components(self):
         """Generate the actual Components from the Templates"""
+        #TODO: change the name of this
         self.components = []
-        self.template_uids = {}
+        self.component_uids = {}
         for k, v in self.locals.items():
-            if isinstance(v, nengo_gui.components.component.Template):
-                self.template_uids[v] = k
-                c = v.create(self)
-                self.gui.component_uids[c.uid] = c
-                self.components.append(c)
+            if isinstance(v, nengo_gui.components.component.Component):
+                self.component_uids[v] = k
+                self.gui.component_uids[id(v)] = v
+                self.components.append(v)
 
         # this ensures NetGraph, AceEditor, and SimControl are first
         self.components.sort(key=lambda x: x.component_order)
 
-    def add_template(self, template):
+    def add_component(self, component):
         """Add a new Component to an existing Page."""
-        c = template.create(self)
-        self.gui.component_uids[c.uid] = c
-
-        self.components.append(c)
-
-        return c
+        #TODO: do we need to return anything here? make a uid?
+        self.gui.component_uids[id(component)] = component
+        uid = self.get_uid(component)
+        component.initialize(self, self.config[component], uid=uid)
+        self.components.append(component)
+        return component
 
     def execute(self, code):
         """Run the given code to generate self.model and self.locals.
@@ -234,14 +234,14 @@ class Page(object):
 
         # make sure the required Components exist
         if '_viz_sim_control' not in self.locals:
-            template = nengo_gui.components.SimControlTemplate()
-            self.locals['_viz_sim_control'] = template
+            c = nengo_gui.components.SimControl()
+            self.locals['_viz_sim_control'] = c
         if '_viz_net_graph' not in self.locals:
-            template = nengo_gui.components.NetGraphTemplate()
-            self.locals['_viz_net_graph'] = template
+            c = nengo_gui.components.NetGraph()
+            self.locals['_viz_net_graph'] = c
         if '_viz_ace_editor' not in self.locals:
-            template = nengo_gui.components.AceEditorTemplate()
-            self.locals['_viz_ace_editor'] = template
+            c = nengo_gui.components.AceEditor()
+            self.locals['_viz_ace_editor'] = c
 
         if self.model is not None:
             if config[self.model].pos is None:
@@ -250,8 +250,9 @@ class Page(object):
                 config[self.model].size = (1.0, 1.0)
 
         for k, v in self.locals.items():
-            if isinstance(v, nengo_gui.components.component.Template):
+            if isinstance(v, nengo_gui.components.component.Component):
                 self.default_labels[v] = k
+                v.initialize(page=self, config=config[v], uid=k)
 
         return config
 
@@ -379,10 +380,8 @@ class Page(object):
 
     def remove_component(self, component):
         """Remove a component from the layout."""
-        del self.gui.component_uids[component.uid]
-        template = component.template
-        uid = self.get_uid(template)
-        self.remove_uid(uid)
+        del self.gui.component_uids[id(component)]
+        self.remove_uid(component.uid)
         self.components.remove(component)
 
     def config_change(self, component, new_cfg, old_cfg):

--- a/nengo_gui/page.py
+++ b/nengo_gui/page.py
@@ -168,7 +168,7 @@ class Page(object):
         """Add a new Component to an existing Page."""
         self.gui.component_uids[id(component)] = component
         uid = self.get_uid(component)
-        component.initialize(self, self.config[component], uid=uid)
+        component.attach(self, self.config[component], uid=uid)
         self.components.append(component)
 
     def execute(self, code):
@@ -250,7 +250,7 @@ class Page(object):
         for k, v in self.locals.items():
             if isinstance(v, nengo_gui.components.Component):
                 self.default_labels[v] = k
-                v.initialize(page=self, config=config[v], uid=k)
+                v.attach(page=self, config=config[v], uid=k)
 
         return config
 

--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -98,7 +98,7 @@ class Server(swi.SimpleWebInterface):
 
         gui = self.server.gui
 
-        component = gui.component_uids[uid]
+        component = gui.component_uids[int(uid)]
         while True:
             try:
                 if gui.finished:
@@ -112,9 +112,9 @@ class Server(swi.SimpleWebInterface):
                     if msg.startswith('config:'):
                         cfg = json.loads(msg[7:])
                         old_cfg = {}
-                        for k in component.template.config_params.keys():
+                        for k in component.config_params.keys():
                             v = getattr(
-                                component.page.config[component.template], k)
+                                component.page.config[component], k)
                             old_cfg[k] = v
                         if not(cfg == old_cfg):
                             # Register config change to the undo stack
@@ -122,7 +122,7 @@ class Server(swi.SimpleWebInterface):
                                 component, cfg, old_cfg)
                         for k, v in cfg.items():
                             setattr(
-                                component.page.config[component.template],
+                                component.page.config[component],
                                 k, v)
                         component.page.modified_config()
                     elif msg.startswith('remove'):

--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -112,7 +112,7 @@ class Server(swi.SimpleWebInterface):
                     if msg.startswith('config:'):
                         cfg = json.loads(msg[7:])
                         old_cfg = {}
-                        for k in component.config_params.keys():
+                        for k in component.config_defaults.keys():
                             v = getattr(
                                 component.page.config[component], k)
                             old_cfg[k] = v

--- a/nengo_gui/static/nengo.js
+++ b/nengo_gui/static/nengo.js
@@ -243,13 +243,16 @@ Nengo.Component.prototype.generate_menu = function() {
     return items;
 };
 
-Nengo.Component.prototype.remove = function(undo_flag) {
+Nengo.Component.prototype.remove = function(undo_flag, report_back) {
     undo_flag = typeof undo_flag !== 'undefined' ? undo_flag : false;
+    report_back = typeof report_back !== 'undefined' ? report_back : true;
 
-    if (undo_flag === true) {
-        this.ws.send('remove_undo');
-    } else {
-        this.ws.send('remove');
+    if (report_back) {
+        if (undo_flag === true) {
+            this.ws.send('remove_undo');
+        } else {
+            this.ws.send('remove');
+        }
     }
     this.parent.removeChild(this.div);
     var index = Nengo.Component.components.indexOf(this);

--- a/nengo_gui/static/nengo.js
+++ b/nengo_gui/static/nengo.js
@@ -243,11 +243,11 @@ Nengo.Component.prototype.generate_menu = function() {
     return items;
 };
 
-Nengo.Component.prototype.remove = function(undo_flag, report_back) {
+Nengo.Component.prototype.remove = function(undo_flag, notify_server) {
     undo_flag = typeof undo_flag !== 'undefined' ? undo_flag : false;
-    report_back = typeof report_back !== 'undefined' ? report_back : true;
+    notify_server = typeof notify_server !== 'undefined' ? notify_server : true;
 
-    if (report_back) {
+    if (notify_server) {
         if (undo_flag === true) {
             this.ws.send('remove_undo');
         } else {

--- a/nengo_gui/static/netgraph.js
+++ b/nengo_gui/static/netgraph.js
@@ -335,7 +335,7 @@ Nengo.NetGraph.prototype.on_message = function(event) {
         var uid = data.uid;
         for (var i = 0; i < Nengo.Component.components.length; i++) {
             if (Nengo.Component.components[i].uid === uid) {
-                Nengo.Component.components[i].remove(true);
+                Nengo.Component.components[i].remove(true, data.report_back);
                 break;
             }
         }

--- a/nengo_gui/static/netgraph.js
+++ b/nengo_gui/static/netgraph.js
@@ -335,7 +335,7 @@ Nengo.NetGraph.prototype.on_message = function(event) {
         var uid = data.uid;
         for (var i = 0; i < Nengo.Component.components.length; i++) {
             if (Nengo.Component.components[i].uid === uid) {
-                Nengo.Component.components[i].remove(true, data.report_back);
+                Nengo.Component.components[i].remove(true, data.notify_server);
                 break;
             }
         }


### PR DESCRIPTION
This gets rid of the Component/Template distinction that complicates the server-side code.

Now that Page and GUI have been reorganized, the entire reason for Templates is gone.  They were originally there because the config file was shared across multiple Viz objects, and so the config file was processed before the actual Components themselves existed.  So the config file actually configured these Component Templates, and the Components (when they were created when a page was actually generated) got their information from the Templates.

But now we don't look at the config file until after the Page is being created, so all that indirection is unnecessary, and so this PR gets rid of the Templates.

Some notes:
 - This slightly changes the .cfg file format, in that it is no longer necessary to refer to ValueTemplate in that file, and it's just Value instead.  For backwards compatibility, ValueTemplate still works (otherwise all old .cfg files would fail).
 - There used to be two separate ```uid```s for the Component and the Template.  The one for the component was just ```id(self)``` and was used by the websocket infrastructure to figure out which component the browser is trying to talk to.  The one for the Template was the python string that could be used to refer to the object.  This is the one used in the .cfg file and is consistent with all the other ```uid``` values in the rest of the system.  In the new code, all ```uid```s in the Python code are always python strings for referring to things, and in the places where we need ```id(self)``` we just call ```id(self)```.
