### PR TITLE
Y axis labels for value plots

### DIFF
--- a/nengo_gui/static/2d_axes.js
+++ b/nengo_gui/static/2d_axes.js
@@ -33,8 +33,6 @@ Nengo.Axes2D = function(parent, args) {
         .attr("class", "axis axis_x unselectable")
         .call(this.axis_x);
 
-
-
     /** define the y-axis */
     this.axis_y = d3.svg.axis()
         .scale(this.scale_y)

--- a/nengo_gui/static/2d_axes.js
+++ b/nengo_gui/static/2d_axes.js
@@ -23,7 +23,7 @@ Nengo.Axes2D = function(parent, args) {
 
     /** spacing between the graph and the outside edges (in pixels) */
     this.set_axes_geometry(args.width, args.height);
-    console.log()
+    
     /** define the x-axis */
     this.axis_x = d3.svg.axis()
         .scale(this.scale_x)
@@ -37,10 +37,13 @@ Nengo.Axes2D = function(parent, args) {
     this.axis_y = d3.svg.axis()
         .scale(this.scale_y)
         .orient("left")
-        .ticks(0)
+        .ticks(2)
+        .tickValues([-1,0,1])
+
     this.axis_y_g = this.svg.append("g")
         .attr("class", "axis axis_y unselectable")
         .call(this.axis_y);
+
 };
 
 Nengo.Axes2D.prototype.set_axes_geometry = function(width, height) {

--- a/nengo_gui/static/2d_axes.js
+++ b/nengo_gui/static/2d_axes.js
@@ -23,7 +23,7 @@ Nengo.Axes2D = function(parent, args) {
 
     /** spacing between the graph and the outside edges (in pixels) */
     this.set_axes_geometry(args.width, args.height);
-
+    console.log()
     /** define the x-axis */
     this.axis_x = d3.svg.axis()
         .scale(this.scale_x)
@@ -37,7 +37,7 @@ Nengo.Axes2D = function(parent, args) {
     this.axis_y = d3.svg.axis()
         .scale(this.scale_y)
         .orient("left")
-        .ticks(2)
+        .ticks(0)
     this.axis_y_g = this.svg.append("g")
         .attr("class", "axis axis_y unselectable")
         .call(this.axis_y);

--- a/nengo_gui/static/2d_axes.js
+++ b/nengo_gui/static/2d_axes.js
@@ -11,6 +11,8 @@
 Nengo.Axes2D = function(parent, args) {
     var self = this;
 
+    this.max_y_width = 100;
+
     /** draw the plot as an SVG */
     this.svg = d3.select(parent).append('svg')
         .attr('width', '100%')
@@ -48,8 +50,7 @@ Nengo.Axes2D.prototype.set_axes_geometry = function(width, height) {
     scale = parseFloat($('#main').css('font-size'));
     this.width = width;
     this.height = height;
-
-    this.ax_left = 1.75 * scale;
+    this.ax_left = this.max_y_width;
     this.ax_right = width - 1.75 * scale;
     this.ax_bottom = height - 1.75 * scale;
     this.ax_top = 1.75 * scale;
@@ -86,3 +87,21 @@ Nengo.Axes2D.prototype.on_resize = function(width, height) {
     this.axis_y_g.call(this.axis_y);
 };
 
+Nengo.Axes2D.prototype.fit_ticks = function(parent){
+    var self = this;
+    setTimeout(function(){
+        var ticks = $(parent.div).find('.tick');
+        var max_w = 0;
+        for (var i = 0; i < ticks.length; i++) {
+            var w = ticks[i].getBoundingClientRect().width
+            console.log(w)
+            if (w > max_w) {
+                max_w = w;
+            }
+        }
+        self.max_y_width = max_w;
+        self.set_axes_geometry();
+        self.on_resize(parent.width, parent.height);
+    }, 1)
+}
+    

--- a/nengo_gui/static/2d_axes.js
+++ b/nengo_gui/static/2d_axes.js
@@ -93,8 +93,7 @@ Nengo.Axes2D.prototype.fit_ticks = function(parent){
         var ticks = $(parent.div).find('.tick');
         var max_w = 0;
         for (var i = 0; i < ticks.length; i++) {
-            var w = ticks[i].getBoundingClientRect().width
-            console.log(w)
+            var w = ticks[i].getBoundingClientRect().width;
             if (w > max_w) {
                 max_w = w;
             }

--- a/nengo_gui/static/2d_axes.js
+++ b/nengo_gui/static/2d_axes.js
@@ -33,17 +33,17 @@ Nengo.Axes2D = function(parent, args) {
         .attr("class", "axis axis_x unselectable")
         .call(this.axis_x);
 
+
+
     /** define the y-axis */
     this.axis_y = d3.svg.axis()
         .scale(this.scale_y)
         .orient("left")
-        .ticks(2)
-        .tickValues([-1,0,1])
+        .tickValues([args.min_value, args.max_value]);
 
     this.axis_y_g = this.svg.append("g")
         .attr("class", "axis axis_y unselectable")
         .call(this.axis_y);
-
 };
 
 Nengo.Axes2D.prototype.set_axes_geometry = function(width, height) {

--- a/nengo_gui/static/value.js
+++ b/nengo_gui/static/value.js
@@ -44,9 +44,9 @@ Nengo.Value = function(parent, sim, args) {
 
     this.update();
     this.on_resize(this.get_screen_width(), this.get_screen_height());
-
-    this.axes2d.axis_y.tickValues([this.axes2d.scale_y.domain()[0], this.axes2d.scale_y.domain()[1]])
+    this.axes2d.axis_y.tickValues([args.min_value, args.max_value]);
 };
+
 Nengo.Value.prototype = Object.create(Nengo.Component.prototype);
 Nengo.Value.prototype.constructor = Nengo.Value;
 
@@ -150,7 +150,7 @@ Nengo.Value.prototype.set_range = function() {
             var max = parseFloat(new_range[1]);
             self.update_range(min, max);
             self.save_layout();
-            self.axes2d.axis_y.tickValues([min,max])
+            self.axes2d.axis_y.tickValues([min, max])
         }
         $('#OK').attr('data-dismiss', 'modal');
     });

--- a/nengo_gui/static/value.js
+++ b/nengo_gui/static/value.js
@@ -45,6 +45,7 @@ Nengo.Value = function(parent, sim, args) {
     this.update();
     this.on_resize(this.get_screen_width(), this.get_screen_height());
     this.axes2d.axis_y.tickValues([args.min_value, args.max_value]);
+    this.axes2d.fit_ticks(this);
 };
 
 Nengo.Value.prototype = Object.create(Nengo.Component.prototype);
@@ -151,6 +152,8 @@ Nengo.Value.prototype.set_range = function() {
             self.update_range(min, max);
             self.save_layout();
             self.axes2d.axis_y.tickValues([min, max])
+            self.axes2d.fit_ticks(self);
+  
         }
         $('#OK').attr('data-dismiss', 'modal');
     });

--- a/nengo_gui/static/value.js
+++ b/nengo_gui/static/value.js
@@ -178,7 +178,6 @@ Nengo.Value.prototype.set_range = function() {
         var h = $(self.div).height();
         self.on_resize(w, h);
     })
-
 }
 
 Nengo.Value.prototype.update_range = function(min, max) {

--- a/nengo_gui/static/value.js
+++ b/nengo_gui/static/value.js
@@ -150,9 +150,6 @@ Nengo.Value.prototype.set_range = function() {
             var max = parseFloat(new_range[1]);
             self.update_range(min, max);
             self.save_layout();
-            console.log(Math.max(min.toString().length, max.toString().length))
-            self.axes2d.y_label_length = Math.max(min.toString().length, max.toString().length)
-            self.axes2d.set_axes_geometry();
             self.axes2d.axis_y.tickValues([min,max])
         }
         $('#OK').attr('data-dismiss', 'modal');

--- a/nengo_gui/static/value.js
+++ b/nengo_gui/static/value.js
@@ -44,6 +44,8 @@ Nengo.Value = function(parent, sim, args) {
 
     this.update();
     this.on_resize(this.get_screen_width(), this.get_screen_height());
+
+    this.axes2d.axis_y.tickValues([this.axes2d.scale_y.domain()[0], this.axes2d.scale_y.domain()[1]])
 };
 Nengo.Value.prototype = Object.create(Nengo.Component.prototype);
 Nengo.Value.prototype.constructor = Nengo.Value;
@@ -148,6 +150,10 @@ Nengo.Value.prototype.set_range = function() {
             var max = parseFloat(new_range[1]);
             self.update_range(min, max);
             self.save_layout();
+            console.log(Math.max(min.toString().length, max.toString().length))
+            self.axes2d.y_label_length = Math.max(min.toString().length, max.toString().length)
+            self.axes2d.set_axes_geometry();
+            self.axes2d.axis_y.tickValues([min,max])
         }
         $('#OK').attr('data-dismiss', 'modal');
     });
@@ -174,6 +180,7 @@ Nengo.Value.prototype.set_range = function() {
         var h = $(self.div).height();
         self.on_resize(w, h);
     })
+
 }
 
 Nengo.Value.prototype.update_range = function(min, max) {

--- a/nengo_gui/static/value.js
+++ b/nengo_gui/static/value.js
@@ -140,7 +140,6 @@ Nengo.Value.prototype.set_range = function() {
     Nengo.modal.footer('ok_cancel', function(e) {
         var new_range = $('#singleInput').val();
         var modal = $('#myModalForm').data('bs.validator');
-
         modal.validate();
         if (modal.hasErrors() || modal.isIncomplete()) {
             return;
@@ -153,7 +152,6 @@ Nengo.Value.prototype.set_range = function() {
             self.save_layout();
             self.axes2d.axis_y.tickValues([min, max])
             self.axes2d.fit_ticks(self);
-  
         }
         $('#OK').attr('data-dismiss', 'modal');
     });


### PR DESCRIPTION
Instead of letting d3 automatically generate ticks as it want, Enforce that it labels the min and max values of the value plot range.

Fix #261