### PR TITLE
Handling of new-style LearningRule Connections

### DIFF
--- a/nengo_gui/components/netgraph.py
+++ b/nengo_gui/components/netgraph.py
@@ -317,10 +317,14 @@ class NetGraph(Component):
             new_post = new_item.post_obj
             if isinstance(old_pre, nengo.ensemble.Neurons):
                 old_pre = old_pre.ensemble
+            if isinstance(old_post, nengo.connection.LearningRule):
+                old_post = old_post.connection.post_obj
             if isinstance(old_post, nengo.ensemble.Neurons):
                 old_post = old_post.ensemble
             if isinstance(new_pre, nengo.ensemble.Neurons):
                 new_pre = new_pre.ensemble
+            if isinstance(new_post, nengo.connection.LearningRule):
+                new_post = new_post.connection.post_obj
             if isinstance(new_post, nengo.ensemble.Neurons):
                 new_post = new_post.ensemble
 
@@ -558,6 +562,8 @@ class NetGraph(Component):
         if isinstance(pre, nengo.ensemble.Neurons):
             pre = pre.ensemble
         post = conn.post_obj
+        if isinstance(post, nengo.connection.LearningRule):
+            post = post.connection.post
         if isinstance(post, nengo.ensemble.Neurons):
             post = post.ensemble
         pre = self.page.get_uid(pre)

--- a/nengo_gui/components/netgraph.py
+++ b/nengo_gui/components/netgraph.py
@@ -564,6 +564,8 @@ class NetGraph(Component):
         post = conn.post_obj
         if isinstance(post, nengo.connection.LearningRule):
             post = post.connection.post
+            if isinstance(post, nengo.base.ObjView):
+                post = post.obj
         if isinstance(post, nengo.ensemble.Neurons):
             post = post.ensemble
         pre = self.page.get_uid(pre)

--- a/nengo_gui/layout.py
+++ b/nengo_gui/layout.py
@@ -104,6 +104,10 @@ class Layout(object):
                 if pre is None:
                     break
             post = c.post_obj
+            if isinstance(post, nengo.connection.LearningRule):
+                post = post.connection.post
+                if isinstance(post, nengo.base.ObjView):
+                    post = post.object
             if isinstance(post, nengo.ensemble.Neurons):
                 post = post.ensemble
             while post not in vertices:


### PR DESCRIPTION
The gui currently crashes if you try to use the new syntax for learning rules.  This quick change just updates things so that it handles them exactly like it did the old syntax.  In some future PR we probably would want a visual indication of the learning rule, but this at least lets people work with learning rules and the new syntax.