### PR TITLE
Fixed axes on raster and xyvalue plots

### DIFF
--- a/nengo_gui/static/raster.js
+++ b/nengo_gui/static/raster.js
@@ -40,6 +40,8 @@ Nengo.Raster = function(parent, sim, args) {
 
     this.update();
     this.on_resize(this.get_screen_width(), this.get_screen_height());
+    this.axes2d.axis_y.tickValues([0, args.n_neurons]);
+    this.axes2d.fit_ticks(this);
 };
 Nengo.Raster.prototype = Object.create(Nengo.Component.prototype);
 Nengo.Raster.prototype.constructor = Nengo.Raster;

--- a/nengo_gui/static/xyvalue.js
+++ b/nengo_gui/static/xyvalue.js
@@ -48,6 +48,7 @@ Nengo.XYValue = function(parent, sim, args) {
              .style('stroke', Nengo.make_colors(1));
 
     this.on_resize(this.get_screen_width(), this.get_screen_height());
+    this.axes2d.fit_ticks(this);
 };
 Nengo.XYValue.prototype = Object.create(Nengo.Component.prototype);
 Nengo.XYValue.prototype.constructor = Nengo.Value;


### PR DESCRIPTION
When I merged #502 I didn't notice that it broke the labelling and layout for the raster plots and the xy plots.  So this is a quick fix to make those look right again.

This is a small change and fixes a pretty big bug in master, so I'll merge it quickly and if there are discussions about a better way of doing this fix, we can do that in a separate PR.