### PR TITLE
Improved updating of display as components change

### DIFF
--- a/nengo_gui/components/action.py
+++ b/nengo_gui/components/action.py
@@ -136,7 +136,7 @@ class CreateGraph(Action):
                 if (isinstance(component, nengo_gui.components.slider.Slider)
                         and component.node is self.obj):
                     self.duplicate = RemoveGraph(net_graph, component)
-                    self.send('delete_graph', uid=id(component))
+                    self.send('delete_graph', uid=component.original_id)
 
         self.act_create_graph()
 
@@ -164,7 +164,7 @@ class CreateGraph(Action):
         self.act_create_graph()
 
     def undo(self):
-        self.send('delete_graph', uid=id(self.component))
+        self.send('delete_graph', uid=self.component.original_id)
         if self.duplicate is not None:
             self.duplicate.undo()
 

--- a/nengo_gui/components/component.py
+++ b/nengo_gui/components/component.py
@@ -30,6 +30,11 @@ class Component(object):
         # to swap out the old Component with the new one.
         self.replace_with = None
 
+        # If we have been swapped out, keep track of the id of the original
+        # component, since that's the identifier needed to refer to it on
+        # the client side
+        self.original_id = id(self)
+
     def attach(self, page, config, uid):
         """Connect the Component to a Page."""
         self.config = config  # the nengo.Config[component] for this component

--- a/nengo_gui/components/netgraph.py
+++ b/nengo_gui/components/netgraph.py
@@ -204,6 +204,7 @@ class NetGraph(Component):
                     try:
                         self.page.add_component(v)
                         old_component.replace_with = v
+                        v.original_id = old_component.original_id
                     except:
                         traceback.print_exc()
                         print('failed to recreate plot for %s' % v)


### PR DESCRIPTION
This addresses #425 and a variety of other fixes.  Basically, if anything that's set in the constructor for a Component is changed, then we need to recreate that Component on the client side.

This fixes the following:
- if you change the dimensionality of a Node, the number of sliders will change
- if you change the dimensionality of an Ensemble or Node, the number of lines in the value graph will change
- if you change from 1 dimension 2 dimensions, the option to show an XY Value plot should appear (or disappear)
- if you add a ```_nengo_html_``` attribute to your Node, then the ```HTML``` plot option should appear.
- changing the label on an item should cause that label to change in the graphs

