### PR TITLE
Fixed broken XY plots

### DIFF
--- a/nengo_gui/static/2d_axes.js
+++ b/nengo_gui/static/2d_axes.js
@@ -4,6 +4,8 @@
  *
  * @param {float} args.width - the width of the axes (in pixels)
  * @param {float} args.height - the height of the axes (in pixels)
+ * @param {bool} args.center_x_axis - should the x-axis be in the middle
+ * @param {bool} args.center_y_axis - should the y-axis be in the middle
  * @param {float} args.min_value - minimum value on y-axis
  * @param {float} args.max_value - maximum value on y-axis
  */
@@ -22,6 +24,9 @@ Nengo.Axes2D = function(parent, args) {
     this.scale_x = d3.scale.linear();
     this.scale_y = d3.scale.linear();
     this.scale_y.domain([args.min_value, args.max_value]);
+
+    this.center_x_axis = args.center_x_axis;
+    this.center_y_axis = args.center_y_axis;
 
     /** spacing between the graph and the outside edges (in pixels) */
     this.set_axes_geometry(args.width, args.height);
@@ -81,9 +86,15 @@ Nengo.Axes2D.prototype.on_resize = function(width, height) {
     this.axis_y
         .tickPadding(this.tick_padding)
         .outerTickSize(this.tick_size, this.tick_size);
-    this.axis_x_g.attr("transform", "translate(0," + this.ax_bottom + ")");
+
+    var x_offset = this.center_x_axis ? (this.ax_bottom + this.ax_top) / 2
+                                      : this.ax_bottom;
+    var y_offset = this.center_y_axis ? (this.ax_left + this.ax_right) / 2
+                                      : this.ax_left;
+
+    this.axis_x_g.attr("transform", "translate(0," + x_offset + ")");
     this.axis_x_g.call(this.axis_x);
-    this.axis_y_g.attr("transform", "translate(" + this.ax_left + ", 0)");
+    this.axis_y_g.attr("transform", "translate(" + y_offset + ", 0)");
     this.axis_y_g.call(this.axis_y);
 };
 
@@ -103,4 +114,3 @@ Nengo.Axes2D.prototype.fit_ticks = function(parent){
         self.on_resize(parent.width, parent.height);
     }, 1)
 }
-    

--- a/nengo_gui/static/xyvalue.js
+++ b/nengo_gui/static/xyvalue.js
@@ -47,8 +47,8 @@ Nengo.XYValue = function(parent, sim, args) {
              .attr('class', 'line')
              .style('stroke', Nengo.make_colors(1));
 
-    this.on_resize(this.get_screen_width(), this.get_screen_height());
     this.axes2d.fit_ticks(this);
+    this.on_resize(this.get_screen_width(), this.get_screen_height());
 };
 Nengo.XYValue.prototype = Object.create(Nengo.Component.prototype);
 Nengo.XYValue.prototype.constructor = Nengo.Value;

--- a/nengo_gui/static/xyvalue.js
+++ b/nengo_gui/static/xyvalue.js
@@ -19,6 +19,8 @@ Nengo.XYValue = function(parent, sim, args) {
     /** for storing the accumulated data */
     this.data_store = new Nengo.DataStore(this.n_lines, this.sim, 0);
 
+    args.center_x_axis = true;
+    args.center_y_axis = true;
     this.axes2d = new Nengo.Axes2D(this.div, args);
     this.axes2d.axis_y.tickValues([args.min_value, args.max_value]);
     this.axes2d.axis_x.tickValues([args.min_value, args.max_value]);
@@ -88,19 +90,6 @@ Nengo.XYValue.prototype.update = function() {
 Nengo.XYValue.prototype.on_resize = function(width, height) {
     this.axes2d.on_resize(width, height);
 
-    //this.scale_x.range([this.margin_left, width - this.margin_right]);
-    //this.scale_y.range([height - this.margin_bottom, this.margin_top]);
-
-    var plot_width = this.axes2d.ax_right - this.axes2d.ax_left;
-    var plot_height = this.axes2d.ax_bottom - this.axes2d.ax_top;
-
-    //Adjust positions of x axis on resize
-    this.axes2d.axis_x_g
-        .attr("transform",
-              "translate(0," + (this.axes2d.ax_top + plot_height / 2) + ")");
-    this.axes2d.axis_y_g
-        .attr("transform",
-              "translate(" + (this.axes2d.ax_left + plot_width / 2) + ",0)");
     this.update();
 
     this.label.style.width = width;


### PR DESCRIPTION
The axes display for XY plots is currently very wrong due to changes introduces in #502 and an attempted (but incomplete) fix in #511.  This returns it to the original display where the lines are always crossed through the middle.  