### PR TITLE
More robust way to compute bounding box for graph ticks

### DIFF
--- a/nengo_gui/static/2d_axes.js
+++ b/nengo_gui/static/2d_axes.js
@@ -93,7 +93,7 @@ Nengo.Axes2D.prototype.fit_ticks = function(parent){
         var ticks = $(parent.div).find('.tick');
         var max_w = 0;
         for (var i = 0; i < ticks.length; i++) {
-            var w = ticks[i].getBoundingClientRect().width;
+            var w = ticks[i].getBBox().width;
             if (w > max_w) {
                 max_w = w;
             }


### PR DESCRIPTION
The old way returned zero a lot in Firefox (tested on 39.0, Windows).  This meant that the ticks would take up exactly zero space, making them unreadable.