### PR TITLE
changed y0 to x1

### DIFF
--- a/nengo_gui/examples/tutorial/13-oscillators.py
+++ b/nengo_gui/examples/tutorial/13-oscillators.py
@@ -18,22 +18,22 @@
 # representing multidimensional data.
 
 # Try adjusting the r value to 0.5.  Try 1.5.  What about 0?
-# Try adjusting the speed s.  What happens when it is very slow (0.5)?
+# Try adjusting the speed s.  What happens when it is very slow (0.5)?  0.1?
 
 import nengo
 
 model = nengo.Network()
 with model:
-    
+
     x = nengo.Ensemble(n_neurons=200, dimensions=2)
 
     synapse = 0.1
     def oscillator(x):
         r = 1
         s = 6
-        return [synapse * -x[1] * s + x[0] * (r - x[0]**2 - x[1]**2) + x[0],
-                synapse *  x[0] * s + x[1] * (r - x[0]**2 - x[1]**2) + x[1]]
-    
+        return [synapse * (-x[1] * s + x[0] * (r - x[0]**2 - x[1]**2)) + x[0],
+                synapse * ( x[0] * s + x[1] * (r - x[0]**2 - x[1]**2)) + x[1]]
+
     nengo.Connection(x, x, synapse=synapse, function=oscillator)
-    
-        
+
+

--- a/nengo_gui/examples/tutorial/13-oscillators.py
+++ b/nengo_gui/examples/tutorial/13-oscillators.py
@@ -4,8 +4,8 @@
 # oscillators.  This gives an Ensemble of neurons that can produce patterns
 # of behaviour all on its own without any external input.  For example, here
 # is a standard cycle in two dimensions:
-#    dx0/dt = -x1 * s + x0 * (r - x0**2 - y0**2)
-#    dx1/dt =  x0 * s + x1 * (r - x0**2 - y0**2)
+#    dx0/dt = -x1 * s + x0 * (r - x0**2 - x1**2)
+#    dx1/dt =  x0 * s + x1 * (r - x0**2 - x1**2)
 # where r is the radius of the circle and s is the speed (in radians per second).
 
 # As discussed in the previous tutorial, we can convert this into a Nengo


### PR DESCRIPTION
was just working through tutorials and noticed that in the comments y0 was used instead of x1 (pretty sure it's supposed to be x1 and this was just missed in changing it over from y0)