### PR TITLE
Fixed calculation of simulation speed

### DIFF
--- a/nengo_gui/components/sim_control.py
+++ b/nengo_gui/components/sim_control.py
@@ -48,16 +48,17 @@ class SimControl(Component):
         self.page.finish()
 
     def control(self, t):
+        self.actual_model_dt = t - self.time
         self.time = t
         self.sim_ticks += 1
 
-        now = time.time()
+        now = time.clock()
         if self.last_tick is not None:
             dt = now - self.last_tick
             if dt == 0:
                 self.skipped += 1
             else:
-                rate = self.model_dt * self.skipped / dt
+                rate = self.actual_model_dt * self.skipped / dt
                 decay = np.exp(-dt / self.rate_tau)
                 self.rate *= decay
                 self.rate += (1 - decay) * rate

--- a/nengo_gui/components/sim_control.py
+++ b/nengo_gui/components/sim_control.py
@@ -1,4 +1,5 @@
 import time
+import timeit
 import struct
 import traceback
 
@@ -52,7 +53,7 @@ class SimControl(Component):
         self.time = t
         self.sim_ticks += 1
 
-        now = time.clock()
+        now = timeit.default_timer()
         if self.last_tick is not None:
             dt = now - self.last_tick
             if dt == 0:


### PR DESCRIPTION
The speed calculation in the bottom-left is often hysterically wrong (most noticeably when running nengo_spinnaker).  This fixes the calculation and means that when using nengo_spinnaker the speed very clearly is at 1.00x realtime.  :)