### PR TITLE
Fix page initialization

### DIFF
--- a/nengo_gui/page.py
+++ b/nengo_gui/page.py
@@ -48,9 +48,9 @@ class Page(object):
         self._sim = None       # the current nengo.Simulator
         self.rebuild = False   # should the model be rebuilt
 
-        self.code = None
-        self.error = None
-        self.stdout = ''
+        self.code = None       # the source code currently displayed
+        self.error = None      # any execute or build error
+        self.stdout = ''       # text printed during execute+build
 
         self.undo_stack = []
         self.redo_stack = []

--- a/nengo_gui/page.py
+++ b/nengo_gui/page.py
@@ -48,6 +48,10 @@ class Page(object):
         self._sim = None       # the current nengo.Simulator
         self.rebuild = False   # should the model be rebuilt
 
+        self.code = None
+        self.error = None
+        self.stdout = ''
+
         self.undo_stack = []
         self.redo_stack = []
 
@@ -182,8 +186,6 @@ class Page(object):
         locals['__file__'] = self.filename
 
         self.code = code
-        self.error = None
-        self.stdout = ''
 
         exec_env = nengo_gui.exec_env.ExecutionEnvironment(self.filename)
         try:


### PR DESCRIPTION
This ensures nengo_gui doesn't crash if Page.execute()
is never called (as is the case when manually starting
up the gui with a pre-defined model)