### PR TITLE
Added check for exiting items in NameFinder

### DIFF
--- a/nengo_gui/namefinder.py
+++ b/nengo_gui/namefinder.py
@@ -31,7 +31,8 @@ class NameFinder(object):
                             n = '%s.%s[%d]' % (net_name, k, i)
                             self.known_name[obj] = n
                 elif isinstance(v, classes):
-                    self.known_name[v] = '%s.%s' % (net_name, k)
+                    if v not in self.known_name:
+                        self.known_name[v] = '%s.%s' % (net_name, k)
 
 
         for type in base_lists:


### PR DESCRIPTION
This was preformed for lists of objects, but not for single objects.

Amazingly, this resolves #563 