### PR TITLE
Fixes accidental selection in browser

### DIFF
--- a/nengo_gui/static/main.css
+++ b/nengo_gui/static/main.css
@@ -11,6 +11,12 @@ body {
     display: flex;
     -webkit-flex-direction: column;
     flex-direction: column;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 


### PR DESCRIPTION
Addresses #599 

This works in Chrome and Safari on Mac; Please check other OSs.  Be sure to check that sliders are still editable, and that ctrl/cmd-a works in the editor window.

On Mac, cmd-a used to select many elements of the GUI that we didn't want selected.