### PR TITLE
Fix label svg sizing

### DIFF
--- a/nengo_gui/static/nengo.js
+++ b/nengo_gui/static/nengo.js
@@ -101,6 +101,7 @@ Nengo.draw_legend = function(parent, labels, color_func, uid) {
               .append("text")
               .attr("x", 15)
               .attr("y", function(d, i){ return i *  20 + 9;})
+              .attr("class", "legend-label")
               .html(function(d, i) {
                     return labels[i];
                });


### PR DESCRIPTION
Current method doesn't work for long labels, because I forgot to include the text as part of the label class...