### PR TITLE
Fix Python 3 `zip` error

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@ to the file like so:
 Please keep this list sorted alphabetically by first name.
 
 - Aaron Voelker <arvoelke@gmail.com>
+- Andrew Mundy <andrew.mundy@manchester.ac.uk>
 - Brent Komer <brent.komer@gmail.com>
 - Chris Eliasmith <celiasmith@uwaterloo.ca>
 - Christopher Chan <c88chan@uwaterloo.ca>

--- a/nengo_gui/components/pointer.py
+++ b/nengo_gui/components/pointer.py
@@ -1,4 +1,5 @@
 import copy
+import itertools
 
 import nengo
 import nengo.spa as spa
@@ -64,7 +65,7 @@ class Pointer(SpaPlot):
             over_threshold = pair_similarities > 0.01
             pair_matches = zip(pair_similarities[over_threshold],
                                np.array(vocab.key_pairs)[over_threshold])
-            matches += pair_matches
+            matches = itertools.chain(matches, pair_matches)
 
         text = ';'.join(['%0.2f%s' % (sim, key) for sim, key in matches])
 


### PR DESCRIPTION
Fixes an error that occurs when, e.g., running `25-spa-parse.py` with Python 3.

Coincidentally, I can't select or copy text from the error pane below the code in Nengo GUI (Firefox 42.0, Arch Linux); is that a bug?