### PR TITLE
Persist configuration options to local storage

### DIFF
--- a/nengo_gui/components/ace_editor.py
+++ b/nengo_gui/components/ace_editor.py
@@ -52,7 +52,7 @@ class AceEditor(Component):
 
     def javascript(self):
         args = json.dumps(dict(active=self.page.gui.interactive))
-        return 'ace_editor = new Nengo.Ace("%s", %s)' % (id(self), args)
+        return 'Nengo.ace = new Nengo.Ace("%s", %s)' % (id(self), args)
 
     def message(self, msg):
         if not self.page.gui.interactive:

--- a/nengo_gui/static/components/netgraph.js
+++ b/nengo_gui/static/components/netgraph.js
@@ -13,21 +13,71 @@ Nengo.NetGraph = function(parent, args) {
     if (args.uid[0] === '<') {
         console.log("invalid uid for NetGraph: " + args.uid);
     }
-    this.scale = 1.0;          // global scaling factor
     this.offsetX = 0;          // global x,y pan offset
     this.offsetY = 0;
-    this.zoom_fonts = false;    // scale fonts when zooming
-    this.font_size = 100;       // font size as a percent of base
-    this.aspect_resize = false;  //preserve aspect ratios on window resize
 
-    var transparent_nets = false;  // Do networks have transparent backgrounds?
-    Object.defineProperty(this, 'transparent_nets', {
+    var scale = 1.0;
+    Object.defineProperty(this, 'scale', {
+        // global scaling factor
         get: function() {
-            return transparent_nets;
+            return scale;
         },
         set: function(val) {
-            if (val === transparent_nets) { return; }
-            transparent_nets = val;
+            if (val === scale) { return; }
+            scale = val;
+            this.update_fonts();
+            this.redraw();
+
+            viewport.scale = scale;
+            viewport.redraw_all();
+        }
+
+    });
+
+    Object.defineProperty(this, 'zoom_fonts', {
+        // scale fonts when zooming
+        get: function() {
+            return Nengo.config.zoom_fonts;
+        },
+        set: function(val) {
+            if (val === this.zoom_fonts) { return; }
+            Nengo.config.zoom_fonts = val;
+            this.update_fonts();
+        }
+    });
+
+    Object.defineProperty(this, 'aspect_resize', {
+        //preserve aspect ratios on window resize
+        get: function() {
+            return Nengo.config.aspect_resize;
+        },
+        set: function(val) {
+            if (val === this.aspect_resize) { return; }
+            Nengo.config.aspect_resize = val;
+
+        }
+
+    });
+
+    Object.defineProperty(this, 'font_size', {
+        get: function() {
+            return Nengo.config.font_size;
+        },
+        set: function(val) {
+            if (val === this.font_size) { return; }
+            Nengo.config.font_size = val;
+            this.update_fonts();
+        }
+    });
+
+    // Do networks have transparent backgrounds?
+    Object.defineProperty(this, 'transparent_nets', {
+        get: function() {
+            return Nengo.config.transparent_nets;
+        },
+        set: function(val) {
+            if (val === this.transparent_nets) { return; }
+            Nengo.config.transparent_nets = val;
             for (var key in this.svg_objects) {
                 var ngi = this.svg_objects[key];
                 ngi.compute_fill();
@@ -35,6 +85,7 @@ Nengo.NetGraph = function(parent, args) {
                     ngi.shape.style["fill-opacity"] = val ? 0.0 : 1.0;
                 }
             }
+
         }
     });
 
@@ -191,14 +242,12 @@ Nengo.NetGraph = function(parent, args) {
             self.offsetY = (self.offsetY + yy) / scale - yy;
 
             self.scale = scale * self.scale;
-            viewport.scale = self.scale;
             viewport.x = self.offsetX;
             viewport.y = self.offsetY;
             viewport.redraw_all();
 
             self.scaleMiniMapViewBox();
 
-            self.update_font_size();
             self.redraw();
 
             /** let the server know what happened */
@@ -266,7 +315,7 @@ Nengo.NetGraph.prototype.on_message = function(event) {
     } else if (data.type === 'pan') {
         this.set_offset(data.pan[0], data.pan[1]);
     } else if (data.type === 'zoom') {
-        this.set_scale(data.zoom);
+        this.scale = data.zoom;
     } else if (data.type === 'expand') {
         var item = this.svg_objects[data.uid];
         item.expand(true,true)
@@ -364,33 +413,12 @@ Nengo.NetGraph.prototype.set_offset = function(x, y) {
 }
 
 
-/** zoom the screen (and redraw accordingly) */
-Nengo.NetGraph.prototype.set_scale = function(scale) {
-    this.scale = scale;
-    this.update_font_size();
-    this.redraw();
-
-    viewport.scale = scale;
-    viewport.redraw_all();
-}
-
-
-Nengo.NetGraph.prototype.update_font_size = function(scale) {
+Nengo.NetGraph.prototype.update_fonts = function() {
     if (this.zoom_fonts) {
         $('#main').css('font-size', 3 * this.scale * this.font_size/100 + 'em');
     } else {
         $('#main').css('font-size', this.font_size/100 + 'em');
     }
-}
-
-Nengo.NetGraph.prototype.set_zoom_fonts = function(value) {
-    this.zoom_fonts = value;
-    this.update_font_size();
-}
-
-Nengo.NetGraph.prototype.set_font_size = function(value) {
-    this.font_size = value;
-    this.update_font_size();
 }
 
 /** redraw all elements */

--- a/nengo_gui/static/config.js
+++ b/nengo_gui/static/config.js
@@ -21,10 +21,16 @@ Nengo.Config = function(parent, args) {
         });
     };
 
+    // General options accessible through Configuration Options
     define_option("transparent_nets", false);
     define_option("aspect_resize", false);
     define_option("zoom_fonts", false);
     define_option("font_size", 100);
+
+    // Ace editor options
+    define_option("hide_editor", false);
+    define_option("editor_width", 580);
+    define_option("editor_font_size", 12);
 };
 
 Nengo.Config.prototype.restore_defaults = function() {

--- a/nengo_gui/static/config.js
+++ b/nengo_gui/static/config.js
@@ -1,0 +1,38 @@
+Nengo.Config = function(parent, args) {
+    var self = this;
+
+    define_option = function(key, default_val) {
+        var type = typeof(default_val);
+        Object.defineProperty(self, key, {
+            get: function() {
+                var val = localStorage.getItem("ng." + key) || default_val;
+                if (type === "boolean") {
+                    return val === "true";
+                } else if (type === "number") {
+                    return Number(val);
+                } else {
+                    return val;
+                }
+            },
+            set: function(val) {
+                return localStorage.setItem("ng." + key, val);
+            },
+            enumerable: true
+        });
+    };
+
+    define_option("transparent_nets", false);
+    define_option("aspect_resize", false);
+    define_option("zoom_fonts", false);
+    define_option("font_size", 100);
+};
+
+Nengo.Config.prototype.restore_defaults = function() {
+    for (var option in this) {
+        if (this.hasOwnProperty(option)) {
+            localStorage.removeItem("ng." + option);
+        }
+    }
+}
+
+Nengo.config = new Nengo.Config();

--- a/nengo_gui/static/modal.js
+++ b/nengo_gui/static/modal.js
@@ -165,15 +165,15 @@ Nengo.Modal.prototype.main_config = function(options) {
         '<div class="checkbox">' +
           '<label for="zoom-fonts" class="control-label">' +
             '<input type="checkbox" id="zoom-fonts">' +
-            'Allow fonts to zoom' +
+            'Scale text when zooming' +
           '</label>' +
           '<div class="help-block with-errors"></div>' +
         '</div>' +
       '</div>' +
       '<div class="form-group">' +
         '<div class="checkbox">' +
-          '<label for="fixed-resize" class="control-label">' +
-            '<input type="checkbox" id="fixed-resize">' +
+          '<label for="aspect-resize" class="control-label">' +
+            '<input type="checkbox" id="aspect-resize">' +
             'Fix aspect ratio of elements on canvas resize' +
           '</label>' +
           '<div class="help-block with-errors"></div>' +
@@ -205,7 +205,10 @@ Nengo.Modal.prototype.main_config = function(options) {
         Nengo.netgraph.set_zoom_fonts($('#zoom-fonts').prop('checked'));
     });
 
-    $('#fixed-resize').prop('checked', options["aspect_resize"]);
+    $('#aspect-resize').prop('checked', Nengo.netgraph.aspect_resize);
+    $('#aspect-resize').change(function () {
+        Nengo.netgraph.aspect_resize = $('#aspect-resize').prop('checked');
+    });
 
     $('#config-fontsize').val(options["font_size"]);
 

--- a/nengo_gui/static/modal.js
+++ b/nengo_gui/static/modal.js
@@ -143,7 +143,7 @@ Nengo.Modal.prototype.tabbed_body = function(tabinfo) {
 /**
  * Sets up the body for main configuration
  */
-Nengo.Modal.prototype.main_config = function(options) {
+Nengo.Modal.prototype.main_config = function() {
     this.clear_body();
 
     var $form = $('<form class="form-horizontal" id ' +
@@ -200,9 +200,9 @@ Nengo.Modal.prototype.main_config = function(options) {
     this.$div.on('shown.bs.modal', function () {
         $('#config-fontsize').focus();
     });
-    $('#zoom-fonts').prop('checked', options["zoom"]);
+    $('#zoom-fonts').prop('checked', Nengo.netgraph.zoom_fonts);
     $('#zoom-fonts').change(function () {
-        Nengo.netgraph.set_zoom_fonts($('#zoom-fonts').prop('checked'));
+        Nengo.netgraph.zoom_fonts = $('#zoom-fonts').prop('checked');
     });
 
     $('#aspect-resize').prop('checked', Nengo.netgraph.aspect_resize);
@@ -210,20 +210,19 @@ Nengo.Modal.prototype.main_config = function(options) {
         Nengo.netgraph.aspect_resize = $('#aspect-resize').prop('checked');
     });
 
-    $('#config-fontsize').val(options["font_size"]);
+    $('#config-fontsize').val(Nengo.netgraph.font_size);
 
-    $('#transparent-nets').prop('checked', options["transparent_nets"]);
+    $('#transparent-nets').prop('checked', Nengo.netgraph.transparent_nets);
     $('#transparent-nets').change(function () {
         Nengo.netgraph.transparent_nets = $('#transparent-nets').prop('checked');
     });
 
     $('#config-fontsize').bind('keyup input', function () {
-        Nengo.netgraph.set_font_size(parseInt($('#config-fontsize').val()));
+        Nengo.netgraph.font_size = parseInt($('#config-fontsize').val());
     });
     $('#config-fontsize').attr('data-my_validator', 'custom');
 
     $('#config-backend').change(function () {
-        console.log($('#config-backend').val());
         sim.set_backend($('#config-backend').val());
     });
 

--- a/nengo_gui/static/top_toolbar.js
+++ b/nengo_gui/static/top_toolbar.js
@@ -103,13 +103,14 @@ Nengo.Toolbar.prototype.config_modal = function () {
 Nengo.Toolbar.prototype.config_modal_show = function() {
     var self = this;
 
-    var options = {zoom: Nengo.netgraph.zoom_fonts,
-                   font_size: Nengo.netgraph.font_size,
-                   aspect_resize: Nengo.netgraph.aspect_resize,
-                   transparent_nets: Nengo.netgraph.transparent_nets};
+    // Get current state in case user clicks cancel
+    var original = {zoom: Nengo.netgraph.zoom_fonts,
+                    font_size: Nengo.netgraph.font_size,
+                    aspect_resize: Nengo.netgraph.aspect_resize,
+                    transparent_nets: Nengo.netgraph.transparent_nets};
 
     Nengo.modal.title('Configure Options');
-    Nengo.modal.main_config(options);
+    Nengo.modal.main_config();
     Nengo.modal.footer('ok_cancel', function(e) {
         var zoom = $('#zoom-fonts').prop('checked');
         var font_size = $('#config-fontsize').val();
@@ -120,15 +121,13 @@ Nengo.Toolbar.prototype.config_modal_show = function() {
         if (modal.hasErrors() || modal.isIncomplete()) {
             return;
         }
-        Nengo.netgraph.set_zoom_fonts(zoom);
-        Nengo.netgraph.set_font_size(parseInt(font_size));
-        Nengo.netgraph.aspect_resize = fixed_resize;
-
         $('#OK').attr('data-dismiss', 'modal');
     },
         function () {  //cancel_function
-            Nengo.netgraph.set_zoom_fonts(options["zoom"]);
-            Nengo.netgraph.set_font_size(options["font_size"]);
+            Nengo.netgraph.zoom_fonts = original["zoom"];
+            Nengo.netgraph.font_size = original["font_size"];
+            Nengo.netgraph.transparent_nets = original["transparent_nets"];
+            Nengo.netgraph.aspect_resize = original["aspect_resize"];
             $('#cancel-button').attr('data-dismiss', 'modal');
     });
 

--- a/nengo_gui/templates/page.html
+++ b/nengo_gui/templates/page.html
@@ -116,6 +116,7 @@
         <script src="static/lib/js/bootstrap.min.js"></script>
         <script src="static/lib/js/validator.js"></script>
         <script src="static/nengo.js"></script>
+        <script src="static/config.js"></script>
         <script src="static/datastore.js"></script>
         <script src="static/components/component.js"></script>
         <script src="static/components/2d_axes.js"></script>

--- a/nengo_gui/tests/test_configuration.py
+++ b/nengo_gui/tests/test_configuration.py
@@ -1,0 +1,29 @@
+import time
+
+from selenium.webdriver import ActionChains
+
+from nengo_gui import testing_tools as tt
+
+
+def test_config_persists(driver):
+    tt.reset_page(driver)
+    actions = ActionChains(driver)
+    button = driver.find_element_by_id("Config_button")
+    actions.move_to_element(button)
+    actions.click()
+    actions.perform()
+    time.sleep(1.0)
+
+    actions = ActionChains(driver)
+    checkbox = driver.find_element_by_id("zoom-fonts")
+    actions.move_to_element(checkbox)
+    actions.click()
+    actions.perform()
+    time.sleep(0.5)
+
+    val = driver.execute_script("return localStorage.getItem('ng.zoom_fonts')")
+    assert val == 'true'
+
+    actions.perform()  # do it again to go back to default (False)
+    val = driver.execute_script("return localStorage.getItem('ng.zoom_fonts')")
+    assert val == 'false'


### PR DESCRIPTION
The bulk of the logic is in `static/config.js`. So far we only persist the 4 configuration options accessible through the gear icon in the top toolbar, but we can add more things easily.

Addresses issue #375.