### PR TITLE
Prevents random numbers from appearing in SP cloud plot.

### DIFF
--- a/nengo_gui/components/pointer.py
+++ b/nengo_gui/components/pointer.py
@@ -67,7 +67,7 @@ class Pointer(SpaPlot):
                                np.array(vocab.key_pairs)[over_threshold])
             matches = itertools.chain(matches, pair_matches)
 
-        text = ';'.join(['%0.2f%s' % (sim, key) for sim, key in matches])
+        text = ';'.join(['%0.2f%s' % ( min(sim, 9.99), key) for sim, key in matches])
 
         # msg sent as a string due to variable size of pointer names
         msg = '%g %s' % (t, text)


### PR DESCRIPTION
If the .vectors attribute of a vocab object is modified to include one or more vectors with a very large norm, the dot products used to calculate the similarities depicted in semantic pointer plots can get big. Currently, the gui assumes these dot products are single digit, and accordingly gets confused and makes plots with extra numbers in them if they aren't. This pull request fixes this problem (issue #438) by clipping any dot products above 9.99. 