### PR TITLE
Optimize display

### DIFF
--- a/nengo_gui/static/components/netgraph.js
+++ b/nengo_gui/static/components/netgraph.js
@@ -181,9 +181,6 @@ Nengo.NetGraph = function(parent, args) {
                 }
                 for (var key in self.svg_conns) {
                     self.svg_conns[key].redraw();
-                    if (self.mm_display) {
-                        self.minimap_conns[key].redraw();
-                    }
                 }
 
                 viewport.x = self.offsetX;
@@ -375,13 +372,6 @@ Nengo.NetGraph.prototype.on_message = function(event) {
         conn.set_recurrent(data.pres[0] === data.posts[0]);
         conn.redraw();
 
-        if (this.mm_display) {
-            var conn_mini = this.minimap_conns[data.uid];
-            conn_mini.set_pres(data.pres);
-            conn_mini.set_posts(data.posts);
-            conn_mini.redraw();
-        }
-
     } else if (data.type === 'delete_graph') {
         var uid = data.uid;
         for (var i = 0; i < Nengo.Component.components.length; i++) {
@@ -429,10 +419,6 @@ Nengo.NetGraph.prototype.redraw = function() {
     }
     for (var key in this.svg_conns) {
         this.svg_conns[key].redraw();
-        
-        if (this.mm_display) {
-            this.minimap_conns[key].redraw();
-        }
     }
 }
 
@@ -462,11 +448,11 @@ Nengo.NetGraph.prototype.create_object = function(info) {
 
 /** create a new NetGraphConnection */
 Nengo.NetGraph.prototype.create_connection = function(info) {
-    var conn = new Nengo.NetGraphConnection(this, info, false);
-    this.svg_conns[info.uid] = conn;
-
-    var conn_mini = new Nengo.NetGraphConnection(this, info, true);
+	var conn_mini = new Nengo.NetGraphConnection(this, info, true);
     this.minimap_conns[info.uid] = conn_mini;
+    
+    var conn = new Nengo.NetGraphConnection(this, info, false, conn_mini);
+    this.svg_conns[info.uid] = conn;
 };
 
 

--- a/nengo_gui/static/components/netgraph.js
+++ b/nengo_gui/static/components/netgraph.js
@@ -355,15 +355,8 @@ Nengo.NetGraph.prototype.on_message = function(event) {
         if (item === undefined) {
             item = this.svg_conns[data.uid];
         }
+        
         item.remove();
-
-        if (this.mm_display) {
-            var item_mini = this.minimap_objects[data.uid];
-            if (item_mini === undefined) {
-                item_mini = this.minimap_conns[data.uid];
-            }
-            item_mini.remove();
-        }
 
     } else if (data.type === 'reconnect') {
         var conn = this.svg_conns[data.uid];

--- a/nengo_gui/static/components/netgraph.js
+++ b/nengo_gui/static/components/netgraph.js
@@ -319,27 +319,33 @@ Nengo.NetGraph.prototype.on_message = function(event) {
     } else if (data.type === 'expand') {
         var item = this.svg_objects[data.uid];
         item.expand(true,true)
-
-        var item_mini = this.minimap_objects[data.uid];
-        item_mini.expand(true,true)
+        
+        if (this.mm_display) {
+            var item_mini = this.minimap_objects[data.uid];
+            item_mini.expand(true,true)
+        }
 
     } else if (data.type === 'collapse') {
         var item = this.svg_objects[data.uid];
         item.collapse(true,true)
 
-        var item_mini = this.minimap_objects[data.uid];
-        item_mini.collapse(true,true)
+        if (this.mm_display) {
+            var item_mini = this.minimap_objects[data.uid];
+            item_mini.collapse(true,true)
+        }
 
     } else if (data.type === 'pos_size') {
         var item = this.svg_objects[data.uid];
         item.set_position(data.pos[0], data.pos[1]);
         item.set_size(data.size[0], data.size[1]);
 
-        var item = this.minimap_objects[data.uid];
-        item.set_position(data.pos[0], data.pos[1]);
-        item.set_size(data.size[0], data.size[1]);
-
-        this.scaleMiniMap();
+        if (this.mm_display) {
+            var item = this.minimap_objects[data.uid];
+            item.set_position(data.pos[0], data.pos[1]);
+            item.set_size(data.size[0], data.size[1]);
+        
+            this.scaleMiniMap();
+        }
 
     } else if (data.type === 'config') {
         // Anything about the config of a component has changed
@@ -363,11 +369,13 @@ Nengo.NetGraph.prototype.on_message = function(event) {
         }
         item.remove();
 
-        var item_mini = this.minimap_objects[data.uid];
-        if (item_mini === undefined) {
-            item_mini = this.minimap_conns[data.uid];
+        if (this.mm_display) {
+            var item_mini = this.minimap_objects[data.uid];
+            if (item_mini === undefined) {
+                item_mini = this.minimap_conns[data.uid];
+            }
+            item_mini.remove();
         }
-        item_mini.remove();
 
     } else if (data.type === 'reconnect') {
         var conn = this.svg_conns[data.uid];
@@ -376,10 +384,12 @@ Nengo.NetGraph.prototype.on_message = function(event) {
         conn.set_recurrent(data.pres[0] === data.posts[0]);
         conn.redraw();
 
-        var conn_mini = this.minimap_conns[data.uid];
-        conn_mini.set_pres(data.pres);
-        conn_mini.set_posts(data.posts);
-        conn_mini.redraw();
+        if (this.mm_display) {
+            var conn_mini = this.minimap_conns[data.uid];
+            conn_mini.set_pres(data.pres);
+            conn_mini.set_posts(data.posts);
+            conn_mini.redraw();
+        }
 
     } else if (data.type === 'delete_graph') {
         var uid = data.uid;
@@ -427,14 +437,18 @@ Nengo.NetGraph.prototype.redraw = function() {
         this.svg_objects[key].redraw_position();
         this.svg_objects[key].redraw_size();
 
-        this.minimap_objects[key].pos = this.svg_objects[key].pos
-        this.minimap_objects[key].size = this.svg_objects[key].size
-        this.minimap_objects[key].redraw_position();
-        this.minimap_objects[key].redraw_size();
+        if (this.mm_display) {
+            this.minimap_objects[key].pos = this.svg_objects[key].pos
+            this.minimap_objects[key].size = this.svg_objects[key].size
+            this.minimap_objects[key].redraw_position();
+            this.minimap_objects[key].redraw_size();
+        }
     }
     for (var key in this.svg_conns) {
         this.svg_conns[key].redraw();
-        this.minimap_conns[key].redraw();
+        if (this.mm_display) {
+            this.minimap_conns[key].redraw();
+        }
     }
 }
 
@@ -519,11 +533,13 @@ Nengo.NetGraph.prototype.toggle_network = function(uid) {
         item.expand();
     }
 
-    var item_mini = this.minimap_objects[uid];
-    if (item_mini.expanded) {
-        item_mini.collapse(true);
-    } else {
-        item_mini.expand();
+    if (this.mm_display) {
+        var item_mini = this.minimap_objects[uid];
+        if (item_mini.expanded) {
+            item_mini.collapse(true);
+        } else {
+            item_mini.expand();
+        }
     }
 }
 

--- a/nengo_gui/static/components/netgraph.js
+++ b/nengo_gui/static/components/netgraph.js
@@ -125,8 +125,10 @@ Nengo.NetGraph = function(parent, args) {
     parent.appendChild(this.svg);
     this.parent = parent;
 
-    this.old_width = $(this.svg).width();
-    this.old_height = $(this.svg).height();
+    this.width = $(this.svg).width();
+    this.height = $(this.svg).height();
+    
+    this.tool_height = $(toolbar.toolbar).height();
 
     /** three separate layers, so that expanded networks are at the back,
      *  then connection lines, and then other items (nodes, ensembles, and
@@ -203,9 +205,8 @@ Nengo.NetGraph = function(parent, args) {
             event.preventDefault();
 
             self.menu.hide_any();
-            var tool_h = $(toolbar.toolbar).height();
-            var x = (event.clientX) / $(self.svg).width()
-            var y = (event.clientY - tool_h) / $(self.svg).height();
+            var x = (event.clientX) / self.width
+            var y = (event.clientY - self.tool_height) / self.height;
 
 
             switch (event.deltaMode) {
@@ -496,17 +497,17 @@ Nengo.NetGraph.prototype.on_resize = function(event) {
         for (var key in this.svg_objects) {
             var item = this.svg_objects[key];
             if (item.depth == 1) {
-                var new_width = item.get_width()*
-                    this.old_width/width / this.scale;
-                var new_height = item.get_height()*
-                    this.old_height/height / this.scale;
+                var new_width = item.get_width() / this.scale;
+                var new_height = item.get_height() / this.scale;
                 item.size = [new_width/(2*width),
                     new_height/(2*height)];               }
         }
     }
 
-    this.old_width = width;
-    this.old_height = height;
+    this.width = width;
+    this.height = height;
+    this.mm_width = $(this.minimap).width();
+    this.mm_height = $(this.minimap).height();
 
     this.redraw();
 };
@@ -514,13 +515,13 @@ Nengo.NetGraph.prototype.on_resize = function(event) {
 
 /** return the pixel width of the SVG times the current scale factor */
 Nengo.NetGraph.prototype.get_scaled_width = function() {
-    return $(this.svg).width() * this.scale;
+    return this.width * this.scale;
 }
 
 
 /** return the pixel height of the SVG times the current scale factor */
 Nengo.NetGraph.prototype.get_scaled_height = function() {
-    return $(this.svg).height() * this.scale;
+    return this.height * this.scale;
 }
 
 
@@ -608,6 +609,9 @@ Nengo.NetGraph.prototype.create_minimap = function () {
     this.minimap.appendChild(this.g_conns_mini);
     this.minimap.appendChild(this.g_items_mini);
 
+    this.mm_width = $(this.minimap).width();
+    this.mm_height = $(this.minimap).height();
+    
     // default display minimap
     this.mm_display = true;
     this.toggleMiniMap();
@@ -690,8 +694,8 @@ Nengo.NetGraph.prototype.scaleMiniMap = function () {
  * main viewport and scale the viewbox to reflect that. */
 Nengo.NetGraph.prototype.scaleMiniMapViewBox = function () {
     if (this.mm_display == true) {
-        var mm_w = $(this.minimap).width();
-        var mm_h = $(this.minimap).height();
+        var mm_w = this.mm_width
+        var mm_h = this.mm_height
 
         var w = mm_w * this.mm_scale;
         var h = mm_h * this.mm_scale;

--- a/nengo_gui/static/components/netgraph_conn.js
+++ b/nengo_gui/static/components/netgraph_conn.js
@@ -237,6 +237,10 @@ Nengo.NetGraphConnection.prototype.remove = function() {
     this.removed = true;
 
     delete this.ng.svg_conns[this.uid];
+    
+    if (!this.minimap) {
+    	this.mini_conn.remove();
+    }
 }
 
 

--- a/nengo_gui/static/components/netgraph_conn.js
+++ b/nengo_gui/static/components/netgraph_conn.js
@@ -50,7 +50,9 @@ Nengo.NetGraphConnection = function(ng, info, minimap, mini_conn) {
         this.parent = null;
     } else {
         this.parent = this.objects[info.parent];
-        this.parent.child_connections.push(this);
+        if (!minimap) {
+        	this.parent.child_connections.push(this);
+        }
     }
 
     /** create the line and its arrowhead marker */
@@ -205,7 +207,7 @@ Nengo.NetGraphConnection.prototype.set_posts = function(posts) {
 
 /** remove this connection */
 Nengo.NetGraphConnection.prototype.remove = function() {
-    if (this.parent !== null) {
+    if (!this.minimap && this.parent !== null) {
         var index = this.parent.child_connections.indexOf(this);
         if (index === -1) {
             console.log('error removing in remove');

--- a/nengo_gui/static/components/netgraph_conn.js
+++ b/nengo_gui/static/components/netgraph_conn.js
@@ -21,7 +21,7 @@ Nengo.NetGraphConnection = function(ng, info, minimap) {
     this.post = null;
 
     this.minimap = minimap;
-    if (minimap == false) {
+    if (!minimap) {
         this.g_conns = ng.g_conns;
         this.objects = ng.svg_objects;
     } else {
@@ -291,10 +291,10 @@ Nengo.NetGraphConnection.prototype.redraw = function() {
         var angle = Math.atan2(post_pos[1] - pre_pos[1], //angle between objects
                                                post_pos[0] - pre_pos[0]);
 
-        var w1 = this.pre.get_width();
-        var h1 = this.pre.get_height();
-        var w2 = this.post.get_width();
-        var h2 = this.post.get_height();
+        var w1 = this.pre.get_screen_width();
+        var h1 = this.pre.get_screen_height();
+        var w2 = this.post.get_screen_width();
+        var h2 = this.post.get_screen_height();
 
         a1 = Math.atan2(h1,w1);
         a2 = Math.atan2(h2,w2);

--- a/nengo_gui/static/components/netgraph_conn.js
+++ b/nengo_gui/static/components/netgraph_conn.js
@@ -9,7 +9,7 @@
  * @param {array of strings} info.pre - uid to connect from and its parents
  * @param {array of strings} info.post - uid to connect to and its parents
  */
-Nengo.NetGraphConnection = function(ng, info, minimap) {
+Nengo.NetGraphConnection = function(ng, info, minimap, mini_conn) {
     this.ng = ng;
     this.uid = info.uid;
 
@@ -21,6 +21,7 @@ Nengo.NetGraphConnection = function(ng, info, minimap) {
     this.post = null;
 
     this.minimap = minimap;
+    this.mini_conn = mini_conn;
     if (!minimap) {
         this.g_conns = ng.g_conns;
         this.objects = ng.svg_objects;
@@ -69,6 +70,9 @@ Nengo.NetGraphConnection.prototype.set_recurrent = function(recurrent) {
     this.remove_line();
     this.recurrent = recurrent;
     this.create_line();
+    
+    // note: mini_conn is not set to recurrent, as we don't want to
+    // display the recurrent conns on the minimap
 }
 
 Nengo.NetGraphConnection.prototype.create_line = function() {
@@ -187,10 +191,18 @@ Nengo.NetGraphConnection.prototype.find_post = function() {
 Nengo.NetGraphConnection.prototype.set_pres = function(pres) {
     this.pres = pres;
     this.set_pre(this.find_pre());
+    
+    if (!this.minimap) {
+    	this.mini_conn.set_pres(pres);
+    }
 }
 Nengo.NetGraphConnection.prototype.set_posts = function(posts) {
     this.posts = posts;
     this.set_post(this.find_post());
+    
+    if (!this.minimap) {
+    	this.mini_conn.set_posts(posts);
+    }
 }
 
 
@@ -325,6 +337,10 @@ Nengo.NetGraphConnection.prototype.redraw = function() {
         angle = 180 / Math.PI * angle;
         this.marker.setAttribute('transform',
                           'translate(' + mx + ',' + my + ') rotate('+ angle +')');
+    }
+    
+    if (!this.minimap && this.ng.mm_display) {
+    	this.mini_conn.redraw();
     }
 }
 /**Function to determine the length of an intersection line through a rectangle

--- a/nengo_gui/static/components/netgraph_conn.js
+++ b/nengo_gui/static/components/netgraph_conn.js
@@ -70,9 +70,6 @@ Nengo.NetGraphConnection.prototype.set_recurrent = function(recurrent) {
     this.remove_line();
     this.recurrent = recurrent;
     this.create_line();
-    
-    // note: mini_conn is not set to recurrent, as we don't want to
-    // display the recurrent conns on the minimap
 }
 
 Nengo.NetGraphConnection.prototype.create_line = function() {

--- a/nengo_gui/static/components/netgraph_item.js
+++ b/nengo_gui/static/components/netgraph_item.js
@@ -745,10 +745,11 @@ Nengo.NetGraphItem.prototype.redraw_size = function() {
 };
 
 Nengo.NetGraphItem.prototype.get_width = function() {
+    if (this.minimap && !this.ng.mm_display) { return 1; }
+    
     if (this.fixed_width !== null) {
         return this.fixed_width;
     }
-
 
     if (this.minimap == false) {
         var w = $(this.ng.svg).width();
@@ -766,6 +767,8 @@ Nengo.NetGraphItem.prototype.get_width = function() {
 }
 
 Nengo.NetGraphItem.prototype.get_height = function() {
+    if (this.minimap && !this.ng.mm_display) { return 1; }
+    
     if (this.fixed_height !== null) {
         return this.fixed_height;
     }
@@ -796,6 +799,8 @@ Nengo.NetGraphItem.prototype.redraw = function() {
 /** determine the pixel location of the centre of the item */
 Nengo.NetGraphItem.prototype.get_screen_location = function() {
     // FIXME this should probably use this.ng.get_scaled_width and this.ng.get_scaled_height
+    if (this.minimap && !this.ng.mm_display) { return [1, 1]; }
+    
     if (this.minimap == false) {
         var w = $(this.ng.svg).width() * this.ng.scale;
         var h = $(this.ng.svg).height() * this.ng.scale;

--- a/nengo_gui/static/components/netgraph_item.js
+++ b/nengo_gui/static/components/netgraph_item.js
@@ -579,6 +579,10 @@ Nengo.NetGraphItem.prototype.remove = function() {
     if (this.depth == 1) {
         this.ng.scaleMiniMap();
     }
+    
+    if (!this.minimap) {
+    	this.mini_item.remove();
+    }
 };
 
 Nengo.NetGraphItem.prototype.constrain_aspect = function() {

--- a/nengo_gui/static/components/netgraph_item.js
+++ b/nengo_gui/static/components/netgraph_item.js
@@ -594,7 +594,7 @@ Nengo.NetGraphItem.prototype.get_displayed_size = function() {
         var h_scale = this.ng.get_scaled_width();
         var v_scale = this.ng.get_scaled_height();
     	var w = this.get_nested_width() * h_scale;
-    	var v = this.get_nested_height() * v_scale;
+    	var h = this.get_nested_height() * v_scale;
 
         if (h * this.aspect < w) {
             w = h * this.aspect;
@@ -612,8 +612,8 @@ Nengo.NetGraphItem.prototype.constrain_position = function() {
     this.constrain_aspect();
 
     if (this.parent !== null) {
-        this.width = Math.max(0.5, this.width);
-        this.height = Math.max(0.5, this.height);
+        this.width = Math.min(0.5, this.width);
+        this.height = Math.min(0.5, this.height);
         
         this.x = Math.min(this.x, 1.0-this.width);
         this.x = Math.max(this.x, this.width);

--- a/nengo_gui/static/components/netgraph_item.js
+++ b/nengo_gui/static/components/netgraph_item.js
@@ -188,9 +188,8 @@ Nengo.NetGraphItem = function(ng, info, minimap, mini_item) {
                         var vertical_resize = event.edges.bottom || event.edges.top;
                         var horizontal_resize = event.edges.left || event.edges.right;
 
-                        var screen_offset = $('#netgraph').offset();
-                        var w = pos[0] - event.clientX + screen_offset.left;
-                        var h = pos[1] - event.clientY + screen_offset.top;
+                        var w = pos[0] - event.clientX + this.ng.offsetX;
+                        var h = pos[1] - event.clientY + this.ng.offsetY;
 
                         if (event.edges.right) {
                             w *= -1;
@@ -752,10 +751,10 @@ Nengo.NetGraphItem.prototype.get_width = function() {
     }
 
     if (this.minimap == false) {
-        var w = $(this.ng.svg).width();
+        var w = this.ng.width;
         var screen_w = this.get_nested_width() * w * this.ng.scale;
     } else {
-        var w = $(this.ng.minimap).width();
+        var w = this.ng.mm_width;
         var screen_w = this.get_nested_width() * w * this.ng.mm_scale;
     };
 
@@ -774,10 +773,10 @@ Nengo.NetGraphItem.prototype.get_height = function() {
     }
 
     if (this.minimap == false) {
-        var h = $(this.ng.svg).height();
+        var h = this.ng.height;
         var screen_h = this.get_nested_height() * h * this.ng.scale;
     } else {
-        var h = $(this.ng.minimap).height();
+        var h = this.ng.mm_height;
         var screen_h = this.get_nested_height() * h * this.ng.mm_scale;
     };
 
@@ -802,14 +801,14 @@ Nengo.NetGraphItem.prototype.get_screen_location = function() {
     if (this.minimap && !this.ng.mm_display) { return [1, 1]; }
     
     if (this.minimap == false) {
-        var w = $(this.ng.svg).width() * this.ng.scale;
-        var h = $(this.ng.svg).height() * this.ng.scale;
+        var w = this.ng.width * this.ng.scale;
+        var h = this.ng.height * this.ng.scale;
 
         var offsetX = this.ng.offsetX * w;
         var offsetY = this.ng.offsetY * h;
     } else {
-        var mm_w = $(this.ng.minimap).width();
-        var mm_h = $(this.ng.minimap).height();
+        var mm_w = this.ng.mm_width;
+        var mm_h = this.ng.mm_height;
 
         var w = mm_w * this.ng.mm_scale;
         var h = mm_h * this.ng.mm_scale;

--- a/nengo_gui/static/components/netgraph_item.js
+++ b/nengo_gui/static/components/netgraph_item.js
@@ -110,7 +110,9 @@ Nengo.NetGraphItem = function(ng, info, minimap, mini_item) {
     } else {
         this.parent = ng.svg_objects[info.parent];
         this.depth = this.parent.depth + 1;
-        this.parent.children.push(this);
+        if (!minimap) {
+        	this.parent.children.push(this);
+        }
     }
 
     /** create the SVG group to hold this item */
@@ -553,7 +555,7 @@ Nengo.NetGraphItem.prototype.remove = function() {
     }
 
     // remove the item from the parent's children list
-    if (this.parent !== null) {
+    if (!this.minimap && this.parent !== null) {
         var index = this.parent.children.indexOf(this);
         this.parent.children.splice(index, 1);
     }


### PR DESCRIPTION
This addresses #276 (lag on firefox when dragging around large networks).  It's still a little bit choppy when dragging a big network around, but significantly improved from what it was like before.

The first improvement comes from only updating the minimap when it is being displayed.  Before we were updating it all the time, so we were effectively doing twice as many updates/redraws as necessary.

The most significant change to the code-base here is that I modified the minimap logic so that the main object takes care of keeping the minimap object up to date (rather than the old method, where the overall netgraph took care of updating both the main objects and the minimap objects).  This means that there is only one place where we need to check if the minimap is open, rather than having to remember to put that check in everywhere we update the object.

The second improvement comes from reducing the number of jquery calls we're making, as those are kind of expensive.  Basically this just involves storing the jquery result in a local variable when we query it (in response to something changing), and then everything else just references that local variable instead of redoing the jquery.  (note: I only did this in `netgraph.js` and `netgraph_item.js`; there are likely other areas of the code that could benefit from the same treatment).