### PR TITLE
Click on file name to save-as

### DIFF
--- a/nengo_gui/static/ace.js
+++ b/nengo_gui/static/ace.js
@@ -197,6 +197,14 @@ Nengo.Ace.prototype.on_message = function (event) {
         } else {
             this.show_console();
         }
+    } else if (msg.filename !== undefined) {
+        if (msg.valid) {
+            $('#filename')[0].innerHTML = msg.filename;
+            // update the URL so reload and bookmarks work as expected
+            history.pushState({}, msg.filename, '/?filename=' + msg.filename);
+        } else {
+            alert(msg.error);
+        }
     } else if (msg.error !== undefined) {
         var line = msg.error.line;
         this.marker = this.editor.getSession()

--- a/nengo_gui/static/top_toolbar.css
+++ b/nengo_gui/static/top_toolbar.css
@@ -43,9 +43,13 @@
 
 #filename{
     float: right;
-    margin-top: 0.5em;
-    margin-right: 1em;
+    padding: 0.5em;
     cursor: default !important;
+}
+
+#filename:hover {
+    color: #eee;
+    background: #666;
 }
 
 #Help_button{

--- a/nengo_gui/static/top_toolbar.js
+++ b/nengo_gui/static/top_toolbar.js
@@ -57,6 +57,9 @@ Nengo.Toolbar = function(filename) {
     $('#Help_button')[0].addEventListener('click', function () {
         Nengo.hotkeys.callMenu();
     });
+    $('#filename')[0].addEventListener('click', function () {
+        self.save_as();
+    });
 
     $('#filename')[0].innerHTML = filename;
 
@@ -167,5 +170,37 @@ Nengo.Toolbar.prototype.csv_modal = function () {
     Nengo.modal.title("Export the graph data to CSV");
     Nengo.modal.text_body("Do you want to save the file?", "info");
     Nengo.modal.footer('confirm_savecsv');
+    Nengo.modal.show();
+}
+
+Nengo.Toolbar.prototype.save_as = function () {
+    var self = this;
+    Nengo.modal.title("Save file as");
+    Nengo.modal.clear_body();
+
+    var filename = $('#filename')[0].innerHTML;
+
+    var $form = $('<form class="form-horizontal" id ' +
+        '="myModalForm"/>').appendTo(Nengo.modal.$body);
+    $('<div class="form-group" id="save-as-group">' +
+        '<input type="text" id="save-as-filename" class="form-control" ' +
+               'value="' + filename + '"/>' +
+      '</div>').appendTo($form);
+
+    Nengo.modal.footer('ok_cancel', function() {
+        var save_as_filename = $('#save-as-filename')[0].value;
+        if (save_as_filename !== filename) {
+            var editor_code = Nengo.ace.editor.getValue();
+            Nengo.ace.ws.send(JSON.stringify({code:editor_code, save:true,
+                                              save_as:save_as_filename}));
+        }
+    });
+    $('#OK').attr('data-dismiss', 'modal');
+    $("#save-as-filename").keypress(function(event) {
+        if (event.which == 13) {
+            event.preventDefault();
+            $('#OK').click();
+        }
+    });
     Nengo.modal.show();
 }

--- a/nengo_gui/tests/test_save_as.py
+++ b/nengo_gui/tests/test_save_as.py
@@ -1,0 +1,57 @@
+import inspect
+import os
+import time
+import nengo_gui # Imported to find project_root
+from nengo_gui import testing_tools as tt
+
+def download_file(driver,name_of_file):
+    time.sleep(1)
+    file_name = driver.find_element_by_xpath('//*[@id="filename"]')
+    file_name.click()
+    time.sleep(0.25)
+
+    field = driver.find_element_by_xpath('//*[@id="save-as-filename"]')
+    time.sleep(0.3)
+    field.clear()
+    time.sleep(0.25)
+    field.send_keys(name_of_file)
+    time.sleep(0.2)
+
+    accept = driver.find_element_by_xpath('//*[@id="OK"]')
+    accept.click()
+
+    time.sleep(5)
+
+def test_save_as(driver):
+    # Saves the default.py file as test_download, tests whether it downloaded
+    # correctly.
+    tt.reset_page(driver)
+    download_file(driver,"nengo_gui/examples/test_download.py")
+
+
+    # Finds files to be read
+    project_root = os.path.dirname(inspect.getfile(nengo_gui))
+    test_file = os.path.join(project_root,"examples/test_download.py")
+    test_file_conf = os.path.join(project_root,"examples/test_download.py.cfg")
+    default_file = os.path.join(project_root,"examples/default.py")
+
+    assert(os.path.isfile(test_file))
+    with open(test_file,'r') as f1:
+        test_code = f1.read()
+    with open(default_file,'r') as f2:
+        default_code = f2.read()
+
+    assert test_code == default_code
+
+    # Deletes downloaded files
+    os.remove(test_file)
+    os.remove(test_file_conf)
+
+    download_file(driver,"nengo_gui/examples/default.py")
+    time.sleep(2)
+    try:
+        alert = driver.switch_to_alert()
+        alert.accept()
+    except:
+        print("No warning present")
+        assert(False)


### PR DESCRIPTION
Here's a first version of save-as.  The current functionality is tied to clicking on the file name, which I don't particularly like, but seems okay for now until we rethink the top toolbar.

If you try to rename to an existing filename, it will give an error message.  If you try to rename to an invalid file name, it will also give an error message.