### PR TITLE
Fix GUI due to change in Nengo

### DIFF
--- a/nengo_gui/config.py
+++ b/nengo_gui/config.py
@@ -10,15 +10,23 @@ class Config(nengo.Config):
         super(Config, self).__init__()
         for cls in [nengo.Ensemble, nengo.Node]:
             self.configures(cls)
-            self[cls].set_param('pos', nengo.params.Parameter(None))
-            self[cls].set_param('size', nengo.params.Parameter(None))
+            self[cls].set_param('pos', nengo.params.Parameter(name='pos',
+                                                              default=None))
+            self[cls].set_param('size', nengo.params.Parameter(name='size',
+                                                               default=None))
         self.configures(nengo.Network)
-        self[nengo.Network].set_param('pos', nengo.params.Parameter(None))
-        self[nengo.Network].set_param('size', nengo.params.Parameter(None))
+        self[nengo.Network].set_param('pos',
+                                      nengo.params.Parameter(name='pos',
+                                                             default=None))
+        self[nengo.Network].set_param('size',
+                                      nengo.params.Parameter(name='size',
+                                                             default=None))
         self[nengo.Network].set_param('expanded',
-                                      nengo.params.Parameter(False))
+                                      nengo.params.Parameter(name='expanded',
+                                                             default=False))
         self[nengo.Network].set_param('has_layout',
-                                      nengo.params.Parameter(False))
+                                      nengo.params.Parameter(name='has_layout',
+                                                             default=False))
 
         for clsname, cls in inspect.getmembers(nengo_gui.components):
             if inspect.isclass(cls):
@@ -26,7 +34,8 @@ class Config(nengo.Config):
                     if cls != nengo_gui.components.component.Component:
                         self.configures(cls)
                         for k, v in cls.config_defaults.items():
-                            self[cls].set_param(k, nengo.params.Parameter(v))
+                            p = nengo.params.Parameter(name=k, default=v)
+                            self[cls].set_param(k, p)
 
     def dumps(self, uids):
         lines = []

--- a/nengo_gui/config.py
+++ b/nengo_gui/config.py
@@ -4,29 +4,33 @@ import nengo
 
 import nengo_gui.components
 
+def make_param(name, default):
+    try:
+        # the most recent way of making Parameter objects
+        p = nengo.params.Parameter(name=name, default=default)
+    except:
+        # this was for older releases of nengo (v2.0.3 and earlier)
+        p = nengo.params.Parameter(default=default)
+    return p
 
 class Config(nengo.Config):
     def __init__(self):
         super(Config, self).__init__()
         for cls in [nengo.Ensemble, nengo.Node]:
             self.configures(cls)
-            self[cls].set_param('pos', nengo.params.Parameter(name='pos',
-                                                              default=None))
-            self[cls].set_param('size', nengo.params.Parameter(name='size',
-                                                               default=None))
+            self[cls].set_param('pos', make_param(name='pos', default=None))
+            self[cls].set_param('size', make_param(name='size', default=None))
         self.configures(nengo.Network)
         self[nengo.Network].set_param('pos',
-                                      nengo.params.Parameter(name='pos',
-                                                             default=None))
+                                      make_param(name='pos', default=None))
         self[nengo.Network].set_param('size',
-                                      nengo.params.Parameter(name='size',
-                                                             default=None))
+                                      make_param(name='size', default=None))
         self[nengo.Network].set_param('expanded',
-                                      nengo.params.Parameter(name='expanded',
-                                                             default=False))
+                                      make_param(name='expanded',
+                                                 default=False))
         self[nengo.Network].set_param('has_layout',
-                                      nengo.params.Parameter(name='has_layout',
-                                                             default=False))
+                                      make_param(name='has_layout',
+                                                 default=False))
 
         for clsname, cls in inspect.getmembers(nengo_gui.components):
             if inspect.isclass(cls):
@@ -34,7 +38,7 @@ class Config(nengo.Config):
                     if cls != nengo_gui.components.component.Component:
                         self.configures(cls)
                         for k, v in cls.config_defaults.items():
-                            p = nengo.params.Parameter(name=k, default=v)
+                            p = make_param(name=k, default=v)
                             self[cls].set_param(k, p)
 
     def dumps(self, uids):


### PR DESCRIPTION
A recent merge in Nengo changed the constructor for nengo.params.Parameter.  This causes the entire GUI to crash horribly.

This change fixes the GUI to work.  It is backwards-compatible so will work with both the recent changes and with the old (release) version.