### PR TITLE
Improved the nengo.params fix

### DIFF
--- a/nengo_gui/config.py
+++ b/nengo_gui/config.py
@@ -8,7 +8,7 @@ def make_param(name, default):
     try:
         # the most recent way of making Parameter objects
         p = nengo.params.Parameter(name=name, default=default)
-    except:
+    except TypeError:
         # this was for older releases of nengo (v2.0.3 and earlier)
         p = nengo.params.Parameter(default=default)
     return p


### PR DESCRIPTION
Pull requires #695 was an emergency fix to repair a broken nengo_gui build ( #694 ) due to a change in nengo.  It got merged immediately, but didn't have a code review about whether it was the right way to fix it.  This is the PR for actually reviewing #695 and doing it better.

@jgosmann has already pointed out that it should be ```except TypeError:``` rather than ```except:```, so that change is here.  Any others?
