### PR TITLE
Added console auto-hide toggle

### DIFF
--- a/nengo_gui/static/ace.js
+++ b/nengo_gui/static/ace.js
@@ -52,6 +52,7 @@ Nengo.Ace = function (uid, args) {
     this.save_disabled = true;
     this.update_trigger = true; // if an update of the model from the code editor is allowed
     this.auto_update = true; // automatically update the model based on the text
+    this.auto_hide_console = true; // automatically hide console if no errors in code
 
     //Setup the button to toggle the code editor
     $('#Toggle_ace').on('click', function(){self.toggle_shown();});
@@ -192,7 +193,7 @@ Nengo.Ace.prototype.on_message = function (event) {
         }
         $(this.console_stdout).text(msg.stdout);
         $(this.console_error).text('');
-        if (msg.stdout === '') {
+        if (msg.stdout === '' && this.auto_hide_console == true) {
             this.hide_console();
         } else {
             this.show_console();

--- a/nengo_gui/static/hotkeys.js
+++ b/nengo_gui/static/hotkeys.js
@@ -86,6 +86,19 @@ Nengo.Hotkeys = function () {
                 Nengo.ace.update_trigger = true;
                 ev.preventDefault();
             }
+            // toggle auto-hide of console with TODO: pick a good shortcut
+            if (ctrl && ev.shiftKey && key == 'h') {
+                Nengo.ace.auto_hide_console = !Nengo.ace.auto_hide_console;
+                if (Nengo.ace.auto_hide_console == false) {
+                    Nengo.ace.console_height = document.getElementById('vmiddle').clientHeight / 4.0;
+                    $('#console').height(Nengo.ace.console_height);
+                    Nengo.ace.show_console();
+                }
+                else {
+                    Nengo.ace.hide_console();
+                }
+                ev.preventDefault();
+            }
         }
     });
 }

--- a/nengo_gui/static/modal.js
+++ b/nengo_gui/static/modal.js
@@ -168,6 +168,8 @@ Nengo.Modal.prototype.help_body = function() {
                  '<td align="right">' + ctrl + '-1</td></tr>'); //TODO: possibly pick a better shortcut key
     $body.append('<tr><td>Toggle auto-update</td>'+
                  '<td align="right">' + ctrl + '-' + shift + '-1</td></tr>');
+    $body.append('<tr><td>Toggle console auto-hide</td>'+
+                 '<td align="right">' + ctrl + '-' + shift + '-h</td></tr>');
     $body.append('<tr><td>Show hotkeys</td>'+
                  '<td align="right">?</td></tr>');
     $body.append('</table>');


### PR DESCRIPTION
Addresses #626 

- ctrl-shift-h is the shortcut at the moment
- added to hotkeys list
- pops up to 1/4 height of vmiddle

right now it's default is auto-hide, but I would suggest making auto-hide false as default