### PR TITLE
Remove console hiding

### DIFF
--- a/nengo_gui/static/ace.css
+++ b/nengo_gui/static/ace.css
@@ -27,6 +27,7 @@
     -moz-user-select: text;
     -ms-user-select: text;
     user-select: text;
+    display: block;
 }
 
 #console pre {

--- a/nengo_gui/static/ace.js
+++ b/nengo_gui/static/ace.js
@@ -40,14 +40,14 @@ Nengo.Ace = function (uid, args) {
     this.console = document.createElement('div');
     this.console.id = 'console';
     $('#rightpane').append(this.console);
-    this.console_height = 100;
-    this.console_hidden = true;
+    this.console_height = Nengo.config.console_height;
     this.console_stdout = document.createElement('pre');
     this.console_error = document.createElement('pre');
     this.console_stdout.id = 'console_stdout';
     this.console_error.id = 'console_error';
     this.console.appendChild(this.console_stdout);
     this.console.appendChild(this.console_error);
+    $('#console').height(this.console_height);
 
     this.save_disabled = true;
     this.update_trigger = true; // if an update of the model from the code editor is allowed
@@ -130,13 +130,19 @@ Nengo.Ace = function (uid, args) {
             edges: { left: true, right: false, bottom: false, top: true}
         })
         .on('resizemove', function (event) {
+            var max = $('#rightpane').height() - 40;
+            var min = 20;
+
             self.console_height -= event.deltaRect.top;
-            if (self.console_height < 20) {
-                self.console_height = 20;
-            }
-            self.width -= event.deltaRect.left;
+
+            self.console_height = Nengo.clip(self.console_height, min, max);
             $('#console').height(self.console_height);
+
+            self.width -= event.deltaRect.left;
             self.redraw();
+        })
+        .on('resizeend', function (event) {
+            Nengo.config.console_height = self.console_height;
         });
 }
 
@@ -192,11 +198,7 @@ Nengo.Ace.prototype.on_message = function (event) {
         }
         $(this.console_stdout).text(msg.stdout);
         $(this.console_error).text('');
-        if (msg.stdout === '') {
-            this.hide_console();
-        } else {
-            this.show_console();
-        }
+        this.console.scrollTop = this.console.scrollHeight;
     } else if (msg.filename !== undefined) {
         if (msg.valid) {
             $('#filename')[0].innerHTML = msg.filename;
@@ -217,7 +219,6 @@ Nengo.Ace.prototype.on_message = function (event) {
         }]);
         $(this.console_stdout).text(msg.stdout);
         $(this.console_error).text(msg.error.trace);
-        this.show_console();
         this.console.scrollTop = this.console.scrollHeight;
     } else {
         console.log(msg);
@@ -235,30 +236,12 @@ Nengo.Ace.prototype.on_resize = function() {
 Nengo.Ace.prototype.show_editor = function () {
     var editor = document.getElementById('rightpane');
     editor.style.display = 'flex';
-    if (!this.console_hidden) {
-        this.console.style.display = 'block';
-    }
     this.redraw();
 }
 
 Nengo.Ace.prototype.hide_editor = function () {
     var editor = document.getElementById('rightpane');
     editor.style.display = 'none';
-    if (!this.console_hidden) {
-        this.console.style.display = 'none';
-    }
-    this.redraw();
-}
-
-Nengo.Ace.prototype.show_console = function () {
-    this.console.style.display = 'block';
-    this.console_hidden = false;
-    this.redraw();
-}
-
-Nengo.Ace.prototype.hide_console = function () {
-    this.console.style.display = 'none';
-    this.console_hidden = true;
     this.redraw();
 }
 

--- a/nengo_gui/static/config.js
+++ b/nengo_gui/static/config.js
@@ -33,6 +33,7 @@ Nengo.Config = function(parent, args) {
     define_option("editor_width", 580);
     define_option("editor_font_size", 12);
     define_option("auto_update", true);
+    define_option("console_height", 100);
 };
 
 Nengo.Config.prototype.restore_defaults = function() {


### PR DESCRIPTION
As an alternate approach for #626 here I've just completely removed console hiding.  

The console is always there, but you can make it smaller (and it doesn't change its size on its own based on message length).  Also, the size of the console is now persistent, so you can shrink it away when you don't want to worry about it, which is almost the same as hiding it (but doesn't require memorizing a hotkey or having some visual indication as to how to get it back).

I'm mostly putting this PR out there for feedback, in comparison to @studywolf 's #698, which provides a hot key to toggle auto-hiding.

I think this PR is simpler and cleaner, but it'd be good to get some other feedback.