### PR TITLE
Enable sliders on nodes with process outputs

### DIFF
--- a/nengo_gui/components/netgraph.py
+++ b/nengo_gui/components/netgraph.py
@@ -10,7 +10,7 @@ import json
 
 from nengo_gui.components.component import Component
 from nengo_gui.components.value import Value
-from nengo_gui.components.slider import Slider
+from nengo_gui.components.slider import OverriddenOutput
 from nengo_gui.modal_js import infomodal
 import nengo_gui.user_action
 import nengo_gui.layout
@@ -219,7 +219,7 @@ class NetGraph(Component):
                         removed_items.append(item)
                     elif not isinstance(new_obj, old_obj.__class__):
                         rebuilt_objects.append(item)
-                    elif (self.get_extra_info(new_obj) != 
+                    elif (self.get_extra_info(new_obj) !=
                           self.get_extra_info(old_obj)):
                         rebuilt_objects.append(item)
 
@@ -527,7 +527,9 @@ class NetGraph(Component):
         '''
         info = {}
         if isinstance(obj, nengo.Node):
-            if obj.output is None or obj.output is Slider.passthrough_fcn:
+            if obj.output is None or (
+                    isinstance(obj.output, OverriddenOutput)
+                    and obj.output.base_output is None):
                 info['passthrough'] = True
             if callable(obj.output) and hasattr(obj.output, '_nengo_html_'):
                 info['html'] = True

--- a/nengo_gui/components/slider.py
+++ b/nengo_gui/components/slider.py
@@ -2,7 +2,13 @@ import numpy as np
 import struct
 import collections
 
-from nengo.processes import Process
+try:
+    from nengo.processes import Process
+except ImportError:
+
+    class Process(object):
+        pass
+
 from nengo.utils.compat import is_iterable
 
 from nengo_gui.components.component import Component
@@ -83,6 +89,9 @@ class Slider(Component):
         self.from_client = np.zeros(node.size_out, dtype=np.float64) * np.nan
         self.override_output = OverriddenOutput(
             self.base_output, self.to_client, self.from_client)
+        if Process.__module__ == "nengo_gui.components.slider":
+            self.override_output = self.override_output.make_step(
+                shape_in=None, shape_out=node.size_out, dt=None, rng=None)
         self.start_value = np.zeros(node.size_out, dtype=np.float64)
         if not (self.base_output is None or
                 callable(self.base_output) or

--- a/nengo_gui/components/slider.py
+++ b/nengo_gui/components/slider.py
@@ -2,7 +2,71 @@ import numpy as np
 import struct
 import collections
 
+from nengo.processes import Process
+from nengo.utils.compat import is_iterable
+
 from nengo_gui.components.component import Component
+
+
+class OverriddenOutput(Process):
+    def __init__(self, base_output, to_client=None, from_client=None):
+        super(OverriddenOutput, self).__init__()
+        self.base_output = base_output
+        self.to_client = to_client
+        self.from_client = from_client
+
+    def make_step(self, shape_in, shape_out, dt, rng):
+        size_out = shape_out[0] if is_iterable(shape_out) else shape_out
+
+        if self.base_output is None:
+            f = self.passthrough
+        elif isinstance(self.base_output, Process):
+            f = self.base_output.make_step(shape_in, shape_out, dt, rng)
+        elif callable(self.base_output):
+            f = self.base_output
+        else:
+            f = self.static
+        return self.Step(size_out, f,
+                         to_client=self.to_client,
+                         from_client=self.from_client)
+
+    @staticmethod
+    def passthrough(t, x):
+        return x
+
+    def static(self, t, *args):
+        return self.base_output
+
+    class Step(object):
+        def __init__(self, size_out, f, to_client=None, from_client=None):
+            self.size_out = size_out
+            self.f = f
+            self.to_client = to_client
+            self.from_client = from_client
+
+            self.last_time = None
+            self.struct = struct.Struct('<%df' % (1 + self.size_out))
+            self.value = np.zeros(size_out)
+
+        def __call__(self, t, *args):
+            # Stop overriding if we've reset
+            if self.last_time is None or t < self.last_time:
+                self.from_client[:] = np.nan
+            self.last_time = t
+
+            val = np.atleast_1d(self.f(t, *args))
+
+            # Only send messages to client when values have changed
+            val_idx = np.isnan(self.from_client)
+            if (self.to_client is not None
+                    and np.any(val[val_idx] != self.value[val_idx])):
+                self.to_client.append(self.struct.pack(t, *val))
+
+            # Override values from the client
+            val[~val_idx] = self.from_client[~val_idx]
+            self.value[:] = val
+            return self.value
+
 
 class Slider(Component):
     """Input control component. Exclusively associated to Nodes"""
@@ -13,16 +77,16 @@ class Slider(Component):
     def __init__(self, node):
         super(Slider, self).__init__()
         self.node = node
-        if node.output is None:
-            node.output = Slider.passthrough_fcn
         self.base_output = node.output
-        self.override = [None] * node.size_out
-        self.last_time = None
-        self.value = np.zeros(node.size_out)
-        self.start_value = np.zeros(node.size_out, dtype=float)
-        self.struct = struct.Struct('<%df' % (1 + node.size_out))
-        self.data = collections.deque()
-        if not callable(self.base_output):
+
+        self.to_client = collections.deque()
+        self.from_client = np.zeros(node.size_out, dtype=np.float64) * np.nan
+        self.override_output = OverriddenOutput(
+            self.base_output, self.to_client, self.from_client)
+        self.start_value = np.zeros(node.size_out, dtype=np.float64)
+        if not (self.base_output is None or
+                callable(self.base_output) or
+                isinstance(self.base_output, Process)):
             self.start_value[:] = self.base_output
 
     def attach(self, page, config, uid):
@@ -34,48 +98,26 @@ class Slider(Component):
 
     def remove_nengo_objects(self, page):
         self.node.output = self.base_output
-        if self.node.output is Slider.passthrough_fcn:
-            self.node.output = None
-
-    def override_output(self, t, *args):
-        if self.last_time is None or t < self.last_time:
-            self.override = [None] * self.node.size_out
-        self.last_time = t
-        if callable(self.base_output):
-            self.value[:] = self.base_output(t, *args)
-            self.data.append(self.struct.pack(t, *self.value))
-        else:
-            self.value[:] = self.base_output
-
-        for i, v in enumerate(self.override):
-            if v is not None:
-                self.value[i] = v
-        return self.value
 
     def javascript(self):
-        info = dict(uid=id(self), n_sliders=len(self.override),
+        info = dict(uid=id(self), n_sliders=self.node.size_out,
                     label=self.label,
                     start_value=[float(x) for x in self.start_value])
         json = self.javascript_config(info)
         return 'new Nengo.Slider(main, sim, %s);' % json
 
     def update_client(self, client):
-        while len(self.data) > 0:
-            data = self.data.popleft()
-            client.write(data, binary=True)
+        while len(self.to_client) > 0:
+            to_client = self.to_client.popleft()
+            client.write(to_client, binary=True)
 
     def message(self, msg):
         index, value = msg.split(',')
         index = int(index)
         if value == 'reset':
-            self.override[index] = None
+            self.from_client[index] = np.nan
         else:
-            value = float(value)
-            self.override[index] = value
+            self.from_client[index] = float(value)
 
     def code_python_args(self, uids):
         return [uids[self.node]]
-
-    @staticmethod
-    def passthrough_fcn(t, x):
-        return x


### PR DESCRIPTION
@celiasmith noticed that you couldn't make sliders when a node had a `Process` as the node output. With this commit, sliders now work properly. I think a few slider bugs might also be fixed with this as I reduced a bit of code duplication, but that's just a guess.

This PR also changes how `node.output` is overridden for all other node output types. The changed version uses processes, so this change breaks compatibility with Nengo 2.0.x, so that should be kept in mind when determining when to merge this commit (and is also why TravisCI fails on this branch).

The new `OverriddenOutput` should be slightly faster in some cases because the (former) `data` list is now a NumPy array where `np.nan` indicates that the value should not be overridden. This array is only modified, not copied, so we save several instances of making a new list of Nones, which may make a marginal difference in some cases.

If I read the old code correctly, data was only ever sent to the client when `callable(node.output)` evaluates to `True`, and it was sent on every timestep. In this PR, I change it so that data is only sent to the client when a value has changed from the previous timestep, and data is now sent to the client for all situations, not just callables. Hopefully I read the old code correctly and intuited why it was only sent then :)