### PR TITLE
Fixed error line computing error for indentation errors

### DIFF
--- a/nengo_gui/exec_env.py
+++ b/nengo_gui/exec_env.py
@@ -72,7 +72,7 @@ def determine_line_number():
     #  note that this is required for indentation errors and other syntax
     #  problems
     trace = traceback.format_exc()
-    pattern = 'File "%s", line ' % filename
+    pattern = 'File "%s", line ' % compiled_filename
     index = trace.find(pattern)
     if index >=0:
         text = trace[index + len(pattern):].split('\n', 1)[0]


### PR DESCRIPTION
My rushed fix from #714 missed a case, causing it to fail to determine line numbers for indentation errors.  This fixes that fix.