### PR TITLE
Fix dt==0 problem on nengo_spinnaker

### DIFF
--- a/nengo_gui/components/sim_control.py
+++ b/nengo_gui/components/sim_control.py
@@ -79,8 +79,9 @@ class SimControl(Component):
                 self.rate += (1 - decay) * rate
                 self.skipped = 1
 
-                # compute current proportion of full speed
-                self.rate_proportion = 1.0 - ((self.rate * self.delay_time) /
+                if self.actual_model_dt > 0:
+                    # compute current proportion of full speed
+                    self.rate_proportion = 1.0 - ((self.rate * self.delay_time) /
                                               self.actual_model_dt)
 
         # if we have a desired proportion, use it to control delay_time


### PR DESCRIPTION
I'm not sure why actual_model_dt can be zero on spinnaker,
but I've seen it happen once so we may as well check for it.