### PR TITLE
Fixes for 0.2 release

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,20 +1,19 @@
-Nengo Viz contributors
-======================
+**********************
+Nengo GUI contributors
+**********************
 
 This is a list of people who have contributed to Nengo GUI.
 Note that this is not the list of copyright holders;
 Applied Brain Research Inc. holds the copyright to
 all Nengo GUI code, except for code that is used under
-various licenses, as described in the LICENSE.md file.
+various licenses, as described in the ``LICENSE.rst`` file.
 
 By adding your name to this file, you are agreeing
 to the Contributor Assignment Agreement found in
-the LICENSE.md file. If you agree, then add yourself
-to the file like so:
+the ``LICENSE.rst`` file. If you agree, then add yourself
+to the file like so::
 
-```
-- Name <email address>
-```
+  - Name <email address>
 
 Please keep this list sorted alphabetically by first name.
 

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -36,17 +36,26 @@ Nengo GUI depends on several open source libraries.
 Contributor Assignment Agreement
 ********************************
 
-Harmony (HA-CAA-I-ANY) Version 1.0
+Based on Harmony (HA-CAA-I-ANY) Version 1.0, with minor changes.
 
 Nengo GUI Individual Contributor Assignment Agreement
 =====================================================
 
-Thank you for your interest in contributing to Nengo GUI ("We" or
-"Us"). This contributor agreement ("Agreement") documents the rights
-granted by contributors to Us. To make this document effective, please
-sign it and send it to Us by electronic submission, following the
-instructions at
-<https://github.com/nengo/nengo_gui/blob/master/CONTRIBUTORS.md>.
+Thank you for your interest in contributing to Nengo GUI, a product of
+Applied Brain Research ("We" or "Us").
+
+This contributor agreement (the "Agreement") documents the rights
+granted by contributors to Us.
+
+By adding your name to the CONTRIBUTORS.rst file at
+<https://github.com/nengo/nengo_gui/blob/master/CONTRIBUTORS.rst>
+you are agreeing to be bound by the Agreement in full.
+
+You agree to inform Us in the relevant pull request(s) if You do not own
+the Copyright to the entire Submission. We will initiate an IP review
+with You to determine the eligibility of the Submission before merging
+the pull request.
+
 This is a legally binding document, so please read it carefully before
 agreeing to it. The Agreement may cover more than one software project
 managed by Us.
@@ -57,10 +66,7 @@ managed by Us.
 "You" means the individual who Submits a Contribution to Us.
 
 "Contribution" means any work of authorship that is Submitted by You
-to Us in which You own or assert ownership of the Copyright. If You do
-not own the Copyright in the entire work of authorship, please follow
-the instructions in
-<https://github.com/nengo/nengo_gui/blob/master/CONTRIBUTORS.md>.
+to Us in which You own or assert ownership of the Copyright.
 
 "Copyright" means all rights protecting works of authorship owned or
 controlled by You, including copyright, moral and neighboring rights,
@@ -73,11 +79,12 @@ project, the Material means the work of authorship to which the
 Contribution was Submitted. After You Submit the Contribution, it may
 be included in the Material.
 
-"Submit" means any form of electronic, verbal, or written
-communication sent to Us or our representatives, including but not
-limited to electronic mailing lists, source code control systems, and
-issue tracking systems that are managed by, or on behalf of, Us for
-the purpose of discussing and improving the Material, but excluding
+"Submit," "Submission" means any form of electronic, verbal, or written
+communication (including any and all Contributions and works of
+authorship) sent to Us or our representatives, including but not limited
+to electronic mailing lists, source code control systems, and issue
+tracking systems that are managed by, or on behalf of, Us for the
+purpose of discussing and improving the Material, but excluding
 communication that is conspicuously marked or otherwise designated in
 writing by You as "Not a Contribution."
 
@@ -190,10 +197,8 @@ You confirm that:
     document. If You are less than eighteen years old, please have
     Your parents or guardian sign the Agreement.
 
-(d) You have followed the instructions in
-    <https://github.com/nengo/nengo_gui/blob/master/CONTRIBUTORS.md>,
-    if You do not own the Copyright in the entire work of authorship
-    Submitted.
+(d) You have informed us in the relevant pull request(s) if You do not
+    own the Copyright to the entire Submission.
 
 4. Disclaimer
 -------------
@@ -220,9 +225,9 @@ CLAIM IS BASED.
 ----------------
 
 **6.1** This Agreement will be governed by and construed in accordance
-with the laws of Applied Brain Research Inc. excluding its conflicts
-of law provisions. Under certain circumstances, the governing law in
-this section might be superseded by the United Nations Convention on
+with the laws of Ontario, Canada excluding its conflicts of law
+provisions. Under certain circumstances, the governing law in this
+section might be superseded by the United Nations Convention on
 Contracts for the International Sale of Goods ("UN Convention") and
 the parties intend to avoid the application of the UN Convention to
 this Agreement and, thus, exclude the application of the UN Convention

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,5 +1,6 @@
+*****************
 Nengo GUI license
-=================
+*****************
 
 Nengo GUI is made available under a proprietary license that permits
 using, copying, sharing, and making derivative works
@@ -9,34 +10,36 @@ If you would like to use Nengo GUI commercially, licenses can be
 purchased from Applied Brain Research, Inc. Please contact
 info@appliedbrainresearch.com for more information.
 
+*************
 Licensed code
-=============
+*************
 
 Nengo GUI depends on several open source libraries.
 
-* [D3](http://d3js.org/) - Used under
-  [MIT license](https://github.com/mbostock/d3/blob/master/LICENSE)
-* [jQuery](http://jquery.com/) - Used under
-  [MIT license](https://github.com/jquery/jquery/blob/master/MIT-LICENSE.txt)
-* [ace](http://ace.c9.io/) - Used under
-  [BSD license](https://github.com/ajaxorg/ace/blob/master/LICENSE)
-* [jQueryFileTree] - Used under
-  [MIT license](http://www.abeautifulsite.net/blog/2008/03/jquery-file-tree/)
-* [Bootstrap](http://getbootstrap.com/) - Used under
-  [MIT license](https://raw.githubusercontent.com/twbs/bootstrap/master/LICENSE)
-  * including [Glyphicons](http://glyphicons.com/)
-* [Grandalf](https://github.com/bdcht/grandalf) - Used under
-  [EPL license](https://github.com/bdcht/grandalf/blob/master/LICENSE)
-* [Validator](https://github.com/1000hz/bootstrap-validator) - Used under
-  [MIT license](http://www.abeautifulsite.net/blog/2008/03/jquery-file-tree/)
+* `D3 <http://d3js.org/>`_ - Used under
+  `MIT license <https://github.com/mbostock/d3/blob/master/LICENSE>`_
+* `jQuery <http://jquery.com/>`_ - Used under
+  `MIT license <https://github.com/jquery/jquery/blob/master/MIT-LICENSE.txt>`_
+* `ace <http://ace.c9.io/>`_ - Used under
+  `BSD license <https://github.com/ajaxorg/ace/blob/master/LICENSE>`_
+* ``jQueryFileTree`` - Used under
+  `MIT license <http://www.abeautifulsite.net/blog/2008/03/jquery-file-tree/>`_
+* `Bootstrap <http://getbootstrap.com/>`_ - Used under
+  `MIT license <https://raw.githubusercontent.com/twbs/bootstrap/master/LICENSE>`_
+  * including `Glyphicons <http://glyphicons.com/>`_
+* `Grandalf <https://github.com/bdcht/grandalf>`_ - Used under
+  `EPL license <https://github.com/bdcht/grandalf/blob/master/LICENSE>`_
+* `Validator <https://github.com/1000hz/bootstrap-validator>`_ - Used under
+  `MIT license <https://github.com/1000hz/bootstrap-validator/blob/master/LICENSE>`_
 
+********************************
 Contributor Assignment Agreement
-================================
+********************************
 
 Harmony (HA-CAA-I-ANY) Version 1.0
 
 Nengo GUI Individual Contributor Assignment Agreement
------------------------------------------------------
+=====================================================
 
 Thank you for your interest in contributing to Nengo GUI ("We" or
 "Us"). This contributor agreement ("Agreement") documents the rights
@@ -48,7 +51,8 @@ This is a legally binding document, so please read it carefully before
 agreeing to it. The Agreement may cover more than one software project
 managed by Us.
 
-### 1. Definitions
+1. Definitions
+--------------
 
 "You" means the individual who Submits a Contribution to Us.
 
@@ -83,43 +87,47 @@ Us.
 "Effective Date" means the date You execute this Agreement or the date
 You first Submit a Contribution to Us, whichever is earlier.
 
-### 2. Grant of Rights
+2. Grant of Rights
+------------------
 
-#### 2.1 Copyright Assignment
+2.1 Copyright Assignment
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 (a) At the time the Contribution is Submitted, You assign to Us all
-right, title, and interest worldwide in all Copyright covering the
-Contribution; provided that this transfer is conditioned upon
-compliance with Section 2.3.
+    right, title, and interest worldwide in all Copyright covering the
+    Contribution; provided that this transfer is conditioned upon
+    compliance with Section 2.3.
 
 (b) To the extent that any of the rights in Section 2.1(a) cannot be
-assigned by You to Us, You grant to Us a perpetual, worldwide,
-exclusive, royalty-free, transferable, irrevocable license under such
-non-assigned rights, with rights to sublicense through multiple tiers
-of sublicensees, to practice such non-assigned rights, including, but
-not limited to, the right to reproduce, modify, display, perform and
-distribute the Contribution; provided that this license is conditioned
-upon compliance with Section 2.3.
+    assigned by You to Us, You grant to Us a perpetual, worldwide,
+    exclusive, royalty-free, transferable, irrevocable license under
+    such non-assigned rights, with rights to sublicense through
+    multiple tiers of sublicensees, to practice such non-assigned
+    rights, including, but not limited to, the right to reproduce,
+    modify, display, perform and distribute the Contribution; provided
+    that this license is conditioned upon compliance with Section 2.3.
 
 (c) To the extent that any of the rights in Section 2.1(a) can neither
-be assigned nor licensed by You to Us, You irrevocably waive and agree
-never to assert such rights against Us, any of our successors in
-interest, or any of our licensees, either direct or indirect; provided
-that this agreement not to assert is conditioned upon compliance with
-Section 2.3.
+    be assigned nor licensed by You to Us, You irrevocably waive and
+    agree never to assert such rights against Us, any of our
+    successors in interest, or any of our licensees, either direct or
+    indirect; provided that this agreement not to assert is
+    conditioned upon compliance with Section 2.3.
 
 (d) Upon such transfer of rights to Us, to the maximum extent
-possible, We immediately grant to You a perpetual, worldwide,
-non-exclusive, royalty-free, transferable, irrevocable license under
-such rights covering the Contribution, with rights to sublicense
-through multiple tiers of sublicensees, to reproduce, modify, display,
-perform, and distribute the Contribution. The intention of the parties
-is that this license will be as broad as possible and to provide You
-with rights as similar as possible to the owner of the rights that You
-transferred. This license back is limited to the Contribution and does
-not provide any rights to the Material.
+    possible, We immediately grant to You a perpetual, worldwide,
+    non-exclusive, royalty-free, transferable, irrevocable license
+    under such rights covering the Contribution, with rights to
+    sublicense through multiple tiers of sublicensees, to reproduce,
+    modify, display, perform, and distribute the Contribution. The
+    intention of the parties is that this license will be as broad as
+    possible and to provide You with rights as similar as possible to
+    the owner of the rights that You transferred. This license back is
+    limited to the Contribution and does not provide any rights to the
+    Material.
 
-#### 2.2 Patent License
+2.2 Patent License
+^^^^^^^^^^^^^^^^^^
 
 For patent claims including, without limitation, method, process, and
 apparatus claims which You own, control or have the right to grant,
@@ -133,7 +141,8 @@ license is granted only to the extent that the exercise of the
 licensed rights infringes such patent claims; and provided that this
 license is conditioned upon compliance with Section 2.3.
 
-#### 2.3 Outbound License
+2.3 Outbound License
+^^^^^^^^^^^^^^^^^^^^
 
 Based on the grant of rights in Sections 2.1 and 2.2, if We include
 Your Contribution in a Material, We may license the Contribution under
@@ -143,46 +152,51 @@ agree to also license the Contribution under the terms of the license
 or licenses which We are using for the Material on the Submission
 Date.
 
-#### 2.4 Moral Rights
+2.4 Moral Rights
+^^^^^^^^^^^^^^^^
 
 If moral rights apply to the Contribution, to the maximum extent
 permitted by law, You waive and agree not to assert such moral rights
 against Us or our successors in interest, or any of our licensees,
 either direct or indirect.
 
-#### 2.5 Our Rights
+2.5 Our Rights
+^^^^^^^^^^^^^^
 
 You acknowledge that We are not obligated to use Your Contribution as
 part of the Material and may decide to include any Contribution We
 consider appropriate.
 
-#### 2.6 Reservation of Rights
+2.6 Reservation of Rights
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Any rights not expressly assigned or licensed under this section are
 expressly reserved by You.
 
-### 3. Agreement
+3. Agreement
+------------
 
 You confirm that:
 
 (a) You have the legal authority to enter into this Agreement.
 
 (b) You own the Copyright and patent claims covering the Contribution
-which are required to grant the rights under Section 2.
+    which are required to grant the rights under Section 2.
 
 (c) The grant of rights under Section 2 does not violate any grant of
-rights which You have made to third parties, including Your employer.
-If You are an employee, You have had Your employer approve this
-Agreement or sign the Entity version of this document. If You are less
-than eighteen years old, please have Your parents or guardian sign the
-Agreement.
+    rights which You have made to third parties, including Your
+    employer. If You are an employee, You have had Your employer
+    approve this Agreement or sign the Entity version of this
+    document. If You are less than eighteen years old, please have
+    Your parents or guardian sign the Agreement.
 
 (d) You have followed the instructions in
-<https://github.com/nengo/nengo_gui/blob/master/CONTRIBUTORS.md>,
-if You do not own the Copyright in the entire work of authorship
-Submitted.
+    <https://github.com/nengo/nengo_gui/blob/master/CONTRIBUTORS.md>,
+    if You do not own the Copyright in the entire work of authorship
+    Submitted.
 
-### 4. Disclaimer
+4. Disclaimer
+-------------
 
 EXCEPT FOR THE EXPRESS WARRANTIES IN SECTION 3, THE CONTRIBUTION IS
 PROVIDED "AS IS". MORE PARTICULARLY, ALL EXPRESS OR IMPLIED WARRANTIES
@@ -192,7 +206,8 @@ ARE EXPRESSLY DISCLAIMED BY YOU TO US AND BY US TO YOU. TO THE EXTENT
 THAT ANY SUCH WARRANTIES CANNOT BE DISCLAIMED, SUCH WARRANTY IS
 LIMITED IN DURATION TO THE MINIMUM PERIOD PERMITTED BY LAW.
 
-### 5. Consequential Damage Waiver
+5. Consequential Damage Waiver
+------------------------------
 
 TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT WILL
 YOU OR US BE LIABLE FOR ANY LOSS OF PROFITS, LOSS OF ANTICIPATED
@@ -201,9 +216,10 @@ AND EXEMPLARY DAMAGES ARISING OUT OF THIS AGREEMENT REGARDLESS OF THE
 LEGAL OR EQUITABLE THEORY (CONTRACT, TORT OR OTHERWISE) UPON WHICH THE
 CLAIM IS BASED.
 
-### 6. Miscellaneous
+6. Miscellaneous
+----------------
 
-6.1 This Agreement will be governed by and construed in accordance
+**6.1** This Agreement will be governed by and construed in accordance
 with the laws of Applied Brain Research Inc. excluding its conflicts
 of law provisions. Under certain circumstances, the governing law in
 this section might be superseded by the United Nations Convention on
@@ -212,23 +228,23 @@ the parties intend to avoid the application of the UN Convention to
 this Agreement and, thus, exclude the application of the UN Convention
 in its entirety to this Agreement.
 
-6.2 This Agreement sets out the entire agreement between You and Us
-for Your Contributions to Us and overrides all other agreements or
+**6.2** This Agreement sets out the entire agreement between You and
+Us for Your Contributions to Us and overrides all other agreements or
 understandings.
 
-6.3 If You or We assign the rights or obligations received through
+**6.3** If You or We assign the rights or obligations received through
 this Agreement to a third party, as a condition of the assignment,
 that third party must agree in writing to abide by all the rights and
 obligations in the Agreement.
 
-6.4 The failure of either party to require performance by the other
-party of any provision of this Agreement in one situation shall not
-affect the right of a party to require such performance at any time in
-the future. A waiver of performance under a provision in one situation
-shall not be considered a waiver of the performance of the provision
-in the future or a waiver of the provision in its entirety.
+**6.4** The failure of either party to require performance by the
+other party of any provision of this Agreement in one situation shall
+not affect the right of a party to require such performance at any
+time in the future. A waiver of performance under a provision in one
+situation shall not be considered a waiver of the performance of the
+provision in the future or a waiver of the provision in its entirety.
 
-6.5 If any provision of this Agreement is found void and
+**6.5** If any provision of this Agreement is found void and
 unenforceable, such provision will be replaced to the extent possible
 with a provision that comes closest to the meaning of the original
 provision and which is enforceable. The terms and conditions set forth

--- a/README.rst
+++ b/README.rst
@@ -36,13 +36,13 @@ To do this, open a command line window and run:
 
 .. code:: shell
 
-   nengo_gui
+   nengo
 
 If you specify a file, it will be loaded:
 
 .. code:: shell
 
-   nengo_gui myfile.py
+   nengo myfile.py
 
 Alternatively, you can start the GUI manually from within your code. To
 do so, add this to the bottom of your file that defines your Nengo model.

--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,20 @@
 *********
-nengo_gui
+Nengo GUI
 *********
 
-HTML5 interactive visualizer for `Nengo <https://github.com/nengo/nengo>`_.
-This lets you see the structure of a Nengo model, plot spiking activity and
-decoded representations, and adjust the inputs while the model is running.
+Nengo GUI is an HTML5-based interactive visualizer for
+large-scale neural models created with
+`Nengo <https://github.com/nengo/nengo>`_.
+The GUI lets you see the structure of a Nengo model,
+plots spiking activity and decoded representations,
+and enables you to alter inputs
+in real time while the model is running.
 
 Requirements
 ============
 
- - Python (tested with Python 2.7 and Python 3.4)
- - Nengo (which also requires NumPy)
+- Python (tested with Python 2.7 and Python 3.4+)
+- Nengo (which requires NumPy)
 
 Installation
 ============
@@ -21,33 +25,26 @@ The simplest way to install is with the standard Python installation system:
 
    pip install nengo_gui
 
-If you would like access the the development version of nengo_gui, you can
-download it from github:
-
-.. code:: shell
-
-   git clone https://github.com/nengo/nengo_gui
-   cd nengo_gui
-   python setup.py develop --user
-
-
-Running nengo_gui
+Running Nengo GUI
 =================
 
-There are two ways to run nengo_gui.  First, you can use it from the command
-line by running the installed script:
+Nengo GUI is accessed through a web browser
+(Google Chrome, Firefox, Safari, etc.)
+To access the correct webpage,
+you must first start the Nengo GUI server.
+To do this, open a command line window and run:
 
 .. code:: shell
 
    nengo_gui
 
-If you specify a file to load, nengo_gui will do so:
+If you specify a file, it will be loaded:
 
 .. code:: shell
 
    nengo_gui myfile.py
 
-Alternatively, you can start nengo_gui manually from within your code.  To
+Alternatively, you can start the GUI manually from within your code. To
 do so, add this to the bottom of your file that defines your Nengo model.
 
 .. code:: python
@@ -55,95 +52,103 @@ do so, add this to the bottom of your file that defines your Nengo model.
    import nengo_gui
    nengo_gui.GUI(__file__).start()
 
-
 Basic usage
 ===========
 
-The graph of the Nengo network should appear.  Rectangles are nengo.Nodes,
-ellipses are nengo.Ensembles, and rounded rectangles are nengo.Networks.
+The graph of the Nengo network should appear. Rectangles are nodes,
+sets of 5 circles are ensembles, and rounded rectangles are networks.
 
 Items can be dragged to move them and resized by dragging their edge or via
 the scroll wheel.
 
 To start (or continue) the simulation, click the play button in the lower
-right.  A spinning gear icon indicates the model is in the process of being
+right. A spinning gear icon indicates the model is in the process of being
 built (or re-built after new graphs are added).
 
 Clicking on an item will show a menu of options, depending on what you
-have clicked on.  Here are some of the standard options for network items:
+have clicked on. Here are some of the standard options for network items:
 
- - value:  show a graph of the decoded output value over time
- - xy-value: show a state-space plot of two decoded values against each other
- - spikes: show the spiking activity of the nengo.Ensemble
- - slider: show sliders that let you adjust the value in a nengo.Node
- - expand/collapse: reveal or hide the insides of a nengo.Network
+- value: show a graph of the decoded output value over time
+- xy-value: show a state-space plot of two decoded values against each other
+- spikes: show the spiking activity of the nengo.Ensemble
+- slider: show sliders that let you adjust the value in a nengo.Node
+- expand/collapse: reveal or hide the insides of a nengo.Network
 
-Once you have graphs, you can also click on them to adjust their options.  For
+Once you have graphs, you can also click on them to adjust their options. For
 example:
 
- - set range: adjust the limits of the graph
- - show label/hide label: whether to show the title at the top of the graph
- - remove: get rid of the graph
+- set range: adjust the limits of the graph
+- show label/hide label: whether to show the title at the top of the graph
+- remove: get rid of the graph
 
-The graphs record their data from previous time steps.  You can show this
+The graphs record their data from previous time steps. You can show this
 previous data by dragging the transparent area in the time axis at the
 bottom (beside the play button).
 
-Testing
+Contributing
 ============
 
-Make sure Nengo_gui is currently working on your machine. Testing is currently
-only officially supported on Linux and Mac.
+We welcome contributions to Nengo GUI through issues and pull requests!
+However, we require contributor assignment agreements
+before pull requests are merged.
+See the ``CONTRIBUTORS.rst`` and ``LICENSE.rst`` files for more information.
 
-To start testing locally:
+Developer installation
+----------------------
 
-Make sure you have a recent version of firefox. For mac users make sure firefox
-is in the applications folder.
-
-Open a terminal and navigate to the nengo_gui folder on your machine
-for example, User/Git/nengo_gui/
-
-**Linux**:
+Developers should install Nengo GUI like so:
 
 .. code:: shell
 
-    sudo pip install -r requirements-test.txt
+   git clone https://github.com/nengo/nengo_gui
+   cd nengo_gui
+   python setup.py develop --user
 
-**Mac**:
+Changes to the files in the ``nengo_gui`` directory will be
+reflected the next time the GUI is run or imported.
+
+Running unit tests
+------------------
+
+Testing is done with the help of `Selenium <http://www.seleniumhq.org/>`_.
+Testing is currently only supported on Linux and Mac OS X.
+
+To run the tests, make sure you have a recent version of Firefox.
+Mac users should ensure that Firefox is in the applications folder.
+
+Additional dependencies are required for running unit tests.
+To install them, open a terminal and navigate to the ``nengo_gui`` folder.
+Execute the command
 
 .. code:: shell
 
-    sudo pip install -r requirements-test.txt
-    sudo pip install -U pytest
-    sudo easy_install selenium
+   pip install --user -r requirements-test.txt
 
-Both:
-      At this point selenium and pytest should be installed.
-      **Now Start up nengo_gui server in another terminal.**
+If you are using a virtual environment,
+you can omit the ``--user`` flag.
 
-Make sure to be in the nengo_gui folder, then run:
+At this point selenium and pytest should be installed,
+so you are ready to run the tests.
 
-.. code:: shell
+To run the tests:
 
-    py.test
+1. Open a terminal window and start the ``nengo`` server.
+2. Open a second terminal window.
+3. Navigate to the ``nengo_gui`` directory.
+4. Run ``py.test``.
 
-This will make sure everything has installed successfully. The console should
-say some number of tests are found, firefox should pop up and it should
-take a couple of minutes to run the base tests.
+The console should say some number of tests are found,
+and Firefox will launch and start doing things on its own.
+It may takes a few minutes to run all tests.
 
-**Writing Tests**
+Writing new unit tests
+----------------------
 
-Look over nengo_gui/tests/test_example.py to learn how to write tests.
+To create tests, simply save a file named
+``test_whatever_the_test_concerns.py`` in ``nengo_gui/tests``
+See ``nengo_gui/tests/test_example.py`` for examples tests.
 
-To create tests, simply save a file named 'test_whatever_the_test_concerns.py'
-(e.g test_plot.py), save it to nengo_gui/tests.
+The following references may also be helpful.
 
-**Additional Info**
-
-Pytest will search for and run all test files in the current
-directory and those below it. So when you run in from terminal make sure to be
-in the appropriate folder e.g ."cd ./../nengo_gui/nengo_gui/tests"
-
-documentation on python selenium can be found here
-http://selenium-python.readthedocs.org/ and documentation on pytest can be
-found here http://pytest.org/latest/.
+- `Selenium-Python documentation <http://selenium-python.readthedocs.org/>`_
+- `pytest documentation <http://pytest.org/latest/>`_

--- a/nengo_gui/__init__.py
+++ b/nengo_gui/__init__.py
@@ -2,4 +2,4 @@ from .gui import GUI
 from .viz import Viz   # deprecated
 from .version import version as __version__
 from .namefinder import NameFinder
-from .main import main
+from .main import main, old_main

--- a/nengo_gui/conftest.py
+++ b/nengo_gui/conftest.py
@@ -20,7 +20,7 @@ def driver(request):
         assert driver.title != "Problem loading page"
 
     except AssertionError:
-        print("ERROR: The nengo_gui server is not currently running. "
+        print("ERROR: The 'nengo' server is not currently running. "
               "Start the server before running tests.")
         raise
 

--- a/nengo_gui/gui.py
+++ b/nengo_gui/gui.py
@@ -81,7 +81,7 @@ class GUI(object):
 
     def start(self, port=8080, browser=True, password=None):
         """Start the web server"""
-        print("Starting nengo_gui server at http://localhost:%d" % port)
+        print("Starting nengo server at http://localhost:%d" % port)
         if password is not None:
             nengo_gui.server.Server.add_user('', password)
             addr = ''

--- a/nengo_gui/main.py
+++ b/nengo_gui/main.py
@@ -4,6 +4,12 @@ import nengo_gui
 import nengo_gui.gui
 
 
+def old_main():
+    print("'nengo_gui' has been renamed to 'nengo'.")
+    print("Please run 'nengo' in the future to avoid this message!\n")
+    main()
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -163,8 +163,7 @@ class Server(swi.SimpleWebInterface):
             if isinstance(component, nengo_gui.components.SimControl):
                 if gui.count_pages() == 0:
                     if gui.interactive:
-                        print("No connections remaining to the nengo_gui "
-                              "server.")
+                        print("No connections remaining to the nengo server.")
                     self.server.shutdown()
 
     def log_message(self, format, *args):

--- a/nengo_gui/version.py
+++ b/nengo_gui/version.py
@@ -1,14 +1,14 @@
 """Nengo GUI version information.
 
 We use semantic versioning (see http://semver.org/).
-Additionally, '-dev' will be added to the version unless the code base
-represents a release version. Commits for which the version doesn't have
-'-dev' should be git tagged with the version.
+and conform to PEP440 (see https://www.python.org/dev/peps/pep-0440/).
+'.devN' will be added to the version unless the code base represents
+a release version. Release versions are git tagged with the version.
 """
 
 name = "nengo_gui"
 version_info = (0, 2, 0)  # (major, minor, patch)
-dev = True
+dev = 0
 
 version = "{v}{dev}".format(v='.'.join(str(v) for v in version_info),
-                            dev='-dev' if dev else '')
+                            dev=('.dev%d' % dev) if dev is not None else '')

--- a/setup.py
+++ b/setup.py
@@ -24,27 +24,37 @@ def read(*filenames, **kwargs):
 root = os.path.dirname(os.path.realpath(__file__))
 version_module = imp.load_source(
     'version', os.path.join(root, 'nengo_gui', 'version.py'))
-description = "Web-based GUI for building and visualizing Nengo models."
-long_description = read('README.rst', 'CHANGES.rst')
 
 setup(
     name="nengo_gui",
     version=version_module.version,
-    author="CNRGlab at UWaterloo",
-    author_email="celiasmith@uwaterloo.ca",
+    author="Applied Brain Research",
+    author_email="info@appliedbrainresearch.com",
     packages=find_packages(),
+    scripts=[],
     include_package_data=True,
+    url="https://github.com/nengo/nengo_gui",
+    license="Free for non-commercial use",
+    description="Web-based GUI for building and visualizing Nengo models.",
+    long_description=read('README.rst', 'CHANGES.rst'),
+    zip_safe=False,
     entry_points={
         'console_scripts': [
             'nengo_gui = nengo_gui:main',
         ]
     },
-    scripts=[],
-    url="https://github.com/nengo/nengo_gui",
-    license="https://github.com/nengo/nengo_gui/blob/master/LICENSE.md",
-    description=description,
-    long_description=long_description,
     install_requires=[
         "nengo",
     ],
+    classifiers=[  # https://pypi.python.org/pypi?%3Aaction=list_classifiers
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Science/Research',
+        'License :: Free for non-commercial use',
+        'Operating System :: OS Independent',
+        'Programming Language :: JavaScript',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ setup(
     zip_safe=False,
     entry_points={
         'console_scripts': [
-            'nengo_gui = nengo_gui:main',
+            'nengo_gui = nengo_gui:old_main',
+            'nengo = nengo_gui:main',
         ]
     },
     install_requires=[


### PR DESCRIPTION
This does a few minor things in preparation for the 0.2 release. Specifically:

- Convert `.md` files to` .rst` for consistency with Nengo and README.rst.
- Update license with minor nits found by Pete (as done in Nengo)
- Update version numbering scheme to conform to PEP440
- Edit some parts of the README
- Make a `nengo` script and deprecate the `nengo_gui` script

See individual commits for more information.

**Before this PR is merged** the following contributors need to sign ``CONTRIBUTORS.rst``, as we missed them when merging pull requests.

- [x] @pblouw 
- [x] @rsimmons1 

To sign the file, please make a commit adding yourself to the ``CONTRIBUTORS.rst`` file. That commit can be pushed to this branch (or if you prefer, you make a separate branch and PR for it).

Please read that file, as well as the assignment agreement in ``LICENSE.rst``. If you're unsure about what the agreement means, please ask either me or @tcstewar!