### PR TITLE
Fixed typo causing autosync to clear

### DIFF
--- a/nengo_gui/static/top_toolbar.js
+++ b/nengo_gui/static/top_toolbar.js
@@ -119,7 +119,7 @@ Nengo.Toolbar.prototype.config_modal_show = function() {
     var original = {zoom: Nengo.netgraph.zoom_fonts,
                     font_size: Nengo.netgraph.font_size,
                     aspect_resize: Nengo.netgraph.aspect_resize,
-                    sync_editor: Nengo.ace.auto_update,
+                    auto_update: Nengo.ace.auto_update,
                     transparent_nets: Nengo.netgraph.transparent_nets,
                     scriptdir: Nengo.config.scriptdir};
 


### PR DESCRIPTION
A variable with the wrong name was causing this option to be cleared whenever the config menu "Cancel" button was clicked.

I believe this is the source of the bug where every now and then someone would find that their network diagram suddenly stopped being updated.