### PR TITLE
Fix a number of server compatibility issues

### DIFF
--- a/nengo_gui/main.py
+++ b/nengo_gui/main.py
@@ -62,7 +62,7 @@ def main():
             raise ValueError("Password protection only allowed with SSL.")
     else:
         server_settings = GuiServerSettings(
-            ('localhost', 8080), args.auto_shutdown[0], ssl_cert=args.cert[0],
+            ('::', 8080), args.auto_shutdown[0], ssl_cert=args.cert[0],
             ssl_key=args.key[0])
 
     try:

--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -261,7 +261,7 @@ class HttpWsRequestHandler(server.BaseHTTPRequestHandler):
         else:
             raise BadRequest()
 
-    def get_expected_origins(self):
+    def is_expected_origin(self, origin):
         raise NotImplementedError()
 
     def upgrade_to_ws(self):
@@ -271,11 +271,9 @@ Connection: Upgrade
 Sec-WebSocket-Accept: {sec}
 
 '''
-        valid_srv_addrs = self.get_expected_origins()
-
         try:
             origin = urlparse(self.headers['Origin'])
-            assert origin.netloc.lower() in valid_srv_addrs
+            assert self.is_expected_origin(origin.netloc.lower())
         except KeyError:
             raise Forbidden()
         except AssertionError:
@@ -283,7 +281,7 @@ Sec-WebSocket-Accept: {sec}
 
         try:
             host = self.headers['Host'].lower()
-            assert host in valid_srv_addrs
+            assert self.is_expected_origin(host)
             key = self.headers['Sec-WebSocket-Key']
             assert len(base64.b64decode(key)) == 16
         except KeyError:

--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -115,6 +115,7 @@ class ManagedThreadHttpServer(socketserver.ThreadingMixIn, server.HTTPServer):
     to allow a proper shutdown."""
 
     daemon_threads = True  # this ensures all spawned threads exit
+    address_family = socket.AF_INET6
 
     def __init__(self, *args, **kwargs):
         server.HTTPServer.__init__(self, *args, **kwargs)

--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -266,12 +266,12 @@ class HttpWsRequestHandler(server.BaseHTTPRequestHandler):
         raise NotImplementedError()
 
     def upgrade_to_ws(self):
-        response = '''HTTP/1.1 101 Switching Protocols
-Upgrade: websocket
-Connection: Upgrade
-Sec-WebSocket-Accept: {sec}
+        response = (
+            'HTTP/1.1 101 Switching Protocols\r\n' +
+            'Upgrade: websocket\r\n' +
+            'Connection: Upgrade\r\n' +
+            'Sec-WebSocket-Accept: {sec}\r\n\r\n')
 
-'''
         try:
             origin = urlparse(self.headers['Origin'])
             assert self.is_expected_origin(origin.netloc.lower())

--- a/nengo_gui/tests/test_server.py
+++ b/nengo_gui/tests/test_server.py
@@ -93,8 +93,8 @@ Sec-WebSocket-Version: 13
             def ws_default(self):
                 pass
 
-            def get_expected_origins(self):
-                return ['localhost:80']
+            def is_expected_origin(self, origin):
+                return True
 
         handler = HandlerClass(request, 'localhost', ServerMock())
         # Ignore errors in decoding because binary WebSocket data might follow
@@ -120,8 +120,8 @@ Sec-WebSocket-Version: 13
 ''')
 
         class HandlerClass(server.HttpWsRequestHandler):
-            def get_expected_origins(self):
-                return ['localhost:80']
+            def is_expected_origin(self, origin):
+                return True
 
         handler = HandlerClass(request, 'localhost', ServerMock())
         response = request.file_io.written_data.decode('utf-8')
@@ -190,8 +190,8 @@ Sec-WebSocket-Version: 13
             def cmd(self):
                 self.called = True
 
-            def get_expected_origins(self):
-                return ['localhost:80']
+            def is_expected_origin(self, origin):
+                return True
 
         handler = HandlerClass(request, 'localhost', ServerMock())
         assert handler.called


### PR DESCRIPTION
- This allows IP addresses like `127.0.0.1` as websocket origin for servers listening on localhost. Actually the whole `127.0.0.0/8` is allowed because all of these addresses are reserved for loopback. This is meant to allow direct use of the IP if `localhost` does not resolve correctly.
- Adds IPv6 support and allows `[::1]` (and equivalent addresses) accordingly as websocket origin. This is meant to allow to address the server with `localhost` on computers where this resolves to the IPv6 address (though with a sane configuration the IPv4 address should be tried when the IPv6 address fails).
- Safari complains when you send `LF` instead of `CRLF`, so we're sending `CRLF` now.

This is all meant to address issues reported in #807. However, one issue remains: Firefox does not support using IPv4 addresses instead of `localhost` because it complains that accessing `localStorage` is not a secure operation. I won't fix this for now because it is not related to the server refactoring and I don't understand why exactly Firefox complains (Chrome and Safari are fine with it.)
