### PR TITLE
Add an indicator for failed save.

### DIFF
--- a/nengo_gui/components/ace_editor.py
+++ b/nengo_gui/components/ace_editor.py
@@ -86,6 +86,8 @@ class AceEditor(Editor):
             try:
                 with open(self.page.filename, 'w') as f:
                     f.write(self.current_code)
+                self.pending_messages.append(json.dumps({
+                    'save_success': True}))
             except IOError:
                 print("Could not save %s; permission denied" %
                       self.page.filename)

--- a/nengo_gui/static/ace.js
+++ b/nengo_gui/static/ace.js
@@ -171,6 +171,7 @@ Nengo.Ace.prototype.save_file = function () {
         var editor_code = this.editor.getValue();
         this.ws.send(JSON.stringify({code:editor_code, save:true}));
         this.disable_save();
+        $('#Save_file').addClass('in-progress');
     }
 }
 
@@ -184,7 +185,11 @@ Nengo.Ace.prototype.disable_save = function () {
 
 Nengo.Ace.prototype.on_message = function (event) {
     var msg = JSON.parse(event.data)
-    if (msg.code !== undefined) {
+    if (msg.save_success !== undefined) {
+       if (msg.save_success) {
+            $('#Save_file').removeClass('in-progress');
+       }
+    } else if (msg.code !== undefined) {
         this.editor.setValue(msg.code);
         this.current_code = msg.code;
         this.editor.gotoLine(1);

--- a/nengo_gui/static/top_toolbar.css
+++ b/nengo_gui/static/top_toolbar.css
@@ -69,6 +69,11 @@
     background: #eee;
 }
 
+#top_toolbar_div li.in-progress a.glyphicon {
+    color: #ccc;
+    background: #c22;
+}
+
 #global_config_menu {
     background: purple;
     height: 20em;


### PR DESCRIPTION
Addresses #785.

Colors the save icon red until the server confirmed the save. If the save fails the icon will stay red as indicator of the failure. This should improve the current state of affairs, though it's not a perfect solution:

* It would be best if the save would not fail.
* If it fails a descriptive error message would be better because with the red background it might not be clear what it means.
* The button will give a short red flash on a successful save.

Addressing these points is not trivial due to the asynchronous implementation. If we'd rely on the server to notify the client of the failure that notification might never be received. So we have to treat the save as failed until confirmed otherwise.