### PR TITLE
Logging instead of print

### DIFF
--- a/nengo_gui/components/ace_editor.py
+++ b/nengo_gui/components/ace_editor.py
@@ -1,8 +1,12 @@
 import json
+import logging
 import os
 
 from nengo_gui.components.editor import Editor
 import nengo_gui.exec_env
+
+
+logger = logging.getLogger(__name__)
 
 
 class AceEditor(Editor):
@@ -87,8 +91,8 @@ class AceEditor(Editor):
                 with open(self.page.filename, 'w') as f:
                     f.write(self.current_code)
             except IOError:
-                print("Could not save %s; permission denied" %
-                      self.page.filename)
+                logger.exception("Could not save %s; permission denied",
+                                 self.page.filename)
                 self.page.net_graph.update_code(self.current_code)
         else:
             self.page.net_graph.update_code(self.current_code)

--- a/nengo_gui/components/component.py
+++ b/nengo_gui/components/component.py
@@ -1,4 +1,8 @@
 import json
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 class Component(object):
@@ -60,7 +64,7 @@ class Component(object):
         Any data sent by the client ove the WebSocket will be passed into
         this method.
         """
-        print('unhandled message', msg)
+        logger.warning('unhandled message %s', msg)
 
     def finish(self):
         """Close this Component"""

--- a/nengo_gui/components/netgraph.py
+++ b/nengo_gui/components/netgraph.py
@@ -2,6 +2,7 @@ import time
 import os
 import traceback
 import collections
+import logging
 import threading
 
 import nengo
@@ -14,6 +15,10 @@ from nengo_gui.components.slider import OverriddenOutput
 from nengo_gui.modal_js import infomodal
 import nengo_gui.user_action
 import nengo_gui.layout
+
+
+logger = logging.getLogger(__name__)
+
 
 class NetGraph(Component):
     """Handles computations and communications for NetGraph on the JS side.
@@ -281,8 +286,7 @@ class NetGraph(Component):
                         old_component.replace_with = obj
                         obj.original_id = old_component.original_id
                     except:
-                        traceback.print_exc()
-                        print('failed to recreate plot for %s' % obj)
+                        logger.exception('failed to recreate plot for %s', obj)
                     components.append(obj)
 
         components.sort(key=lambda x: x.component_order)
@@ -398,7 +402,7 @@ class NetGraph(Component):
         try:
             info = json.loads(msg)
         except ValueError:
-            print('invalid message', repr(msg))
+            logger.warning('invalid message %s', repr(msg))
             return
         action = info.get('act', None)
         undo = info.get('undo', None)
@@ -416,15 +420,14 @@ class NetGraph(Component):
                     self.page.undo_stack.append([act])
                     del self.page.redo_stack[:]
                 except:
-                    print('error processing message', repr(msg))
-                    traceback.print_exc()
+                    logger.exception('error processing message %s', repr(msg))
         elif undo is not None:
             if undo == '1':
                 self.undo()
             else:
                 self.redo()
         else:
-            print('received message', msg)
+            logger.debug('received message %s', msg)
 
     def undo(self):
         if self.page.undo_stack:

--- a/nengo_gui/components/netgraph.py
+++ b/nengo_gui/components/netgraph.py
@@ -1,13 +1,13 @@
-import time
-import os
-import traceback
 import collections
+import json
 import logging
+import os
 import threading
+import time
+import traceback
 
 import nengo
 from nengo import spa
-import json
 
 from nengo_gui.components.component import Component
 from nengo_gui.components.value import Value

--- a/nengo_gui/components/sim_control.py
+++ b/nengo_gui/components/sim_control.py
@@ -138,10 +138,6 @@ class SimControl(Component):
         else:
             self.smart_sleep_offset += delay_time
 
-    def config_settings(self, data):
-        for i in data:
-            print(i)
-
     def update_client(self, client):
         now = time.time()
         # send off a ping now and then so we'll notice when connection closes

--- a/nengo_gui/conftest.py
+++ b/nengo_gui/conftest.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os.path
 import socket
 import threading

--- a/nengo_gui/gui.py
+++ b/nengo_gui/gui.py
@@ -2,8 +2,6 @@
 backend."""
 
 import logging
-from __future__ import print_function
-
 import select
 import signal
 import sys

--- a/nengo_gui/gui.py
+++ b/nengo_gui/gui.py
@@ -1,6 +1,7 @@
 """Classes to instantiate and manage the life cycle of the nengo_gui
 backend."""
 
+import logging
 from __future__ import print_function
 
 import select
@@ -11,6 +12,9 @@ import webbrowser
 
 import nengo_gui
 from nengo_gui.guibackend import GuiServer
+
+
+logger = logging.getLogger(__name__)
 
 
 class ServerShutdown(Exception):
@@ -70,25 +74,26 @@ class InteractiveGUI(BaseGUI):
 
     def start(self):
         protocol = 'https:' if self.server.settings.use_ssl else 'http:'
-        print("Starting nengo server at %s//%s:%d" %
-              (protocol, 'localhost', self.server.server_port))
+        logger.info("Starting nengo server at %s//%s:%d",
+                    protocol, 'localhost', self.server.server_port)
 
         if not sys.platform.startswith('win'):
             signal.signal(signal.SIGINT, self._confirm_shutdown)
 
         try:
             self.server.serve_forever(poll_interval=0.02)
-            print("No connections remaining to the nengo_gui server.")
+            logger.info("No connections remaining to the nengo_gui server.")
         except ServerShutdown:
             self.server.shutdown()
         finally:
-            print("Shutting down server...")
+            logger.info("Shutting down server...")
 
             self.server.wait_for_shutdown(0.05)
             n_zombie = sum(thread.is_alive()
                            for thread, _ in self.server.requests)
             if n_zombie > 0:
-                print("%d zombie threads will close abruptly" % n_zombie)
+                logger.warning("%d zombie threads will close abruptly",
+                               n_zombie)
 
     def _confirm_shutdown(self, signum, frame):
         signal.signal(signal.SIGINT, self._immediate_shutdown)
@@ -100,9 +105,9 @@ class InteractiveGUI(BaseGUI):
             if line[0].lower() == 'y':
                 raise ServerShutdown()
             else:
-                print("Resuming...")
+                logger.info("Resuming...")
         else:
-            print("No confirmation received. Resuming...")
+            logger.info("No confirmation received. Resuming...")
         signal.signal(signal.SIGINT, self._confirm_shutdown)
 
     def _immediate_shutdown(self, signum, frame):

--- a/nengo_gui/guibackend.py
+++ b/nengo_gui/guibackend.py
@@ -1,7 +1,5 @@
 """Nengo GUI backend implementation."""
 
-from __future__ import print_function
-
 import hashlib
 import json
 import logging

--- a/nengo_gui/guibackend.py
+++ b/nengo_gui/guibackend.py
@@ -295,7 +295,7 @@ class GuiRequestHandler(server.HttpWsRequestHandler):
         return session
 
     def log_message(self, format, *args):
-        logger.info(format, *args)
+        logger.debug(format, *args)
 
 
 class ModelContext(object):

--- a/nengo_gui/guibackend.py
+++ b/nengo_gui/guibackend.py
@@ -252,7 +252,7 @@ class GuiRequestHandler(server.HttpWsRequestHandler):
                 component.message(msg.data)
                 return True
             except:
-                logging.exception('Error processing: %s', repr(msg.data))
+                logger.exception('Error processing: %s', repr(msg.data))
 
     def _handle_config_msg(self, component, msg):
         cfg = json.loads(msg.data[7:])
@@ -399,6 +399,6 @@ class GuiServer(server.ManagedThreadHttpServer):
             time.sleep(self.settings.auto_shutdown)
             earliest_shutdown = self._last_access + self.settings.auto_shutdown
             if earliest_shutdown < time.time() and len(self.pages) <= 0:
-                logging.info(
+                logger.info(
                     "No connections remaining to the nengo_gui server.")
                 self.shutdown()

--- a/nengo_gui/ipython.py
+++ b/nengo_gui/ipython.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import atexit
 import logging
 import socket

--- a/nengo_gui/ipython.py
+++ b/nengo_gui/ipython.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import atexit
+import logging
 import socket
 import threading
 import time
@@ -16,6 +17,9 @@ from IPython import get_ipython
 from IPython.display import display, HTML
 
 import nengo_gui
+
+
+logger = logging.getLogger(__name__)
 
 
 class ConfigReuseWarning(UserWarning):
@@ -127,7 +131,7 @@ class IPythonViz(object):
                 </div>
             '''.format(url=self.url, id=uuid.uuid4(), height=self.height)))
         else:
-            print("Server is not alive.")
+            logger.error("Server is not alive.")
 
 
 atexit.register(IPythonViz.shutdown_all, timeout=5)

--- a/nengo_gui/layout.py
+++ b/nengo_gui/layout.py
@@ -1,8 +1,13 @@
+import logging
+
 from collections import OrderedDict
 
 import nengo
 from nengo_gui.grandalf.graphs import Vertex, Edge, Graph
 from nengo_gui.grandalf.layouts import VertexViewer, SugiyamaLayout
+
+
+logger = logging.getLogger(__name__)
 
 
 class Layout(object):
@@ -35,7 +40,7 @@ class Layout(object):
             if len(self.unexamined_networks) == 0:
                 # there are no networks left we haven't looked into
                 # this should not happen in a valid nengo.Network
-                print("could not find parent of", obj)
+                logger.error("could not find parent of %s", obj)
                 return None
             # grab the next network we haven't looked into
             net = self.unexamined_networks.pop(0)
@@ -120,7 +125,7 @@ class Layout(object):
             if pre is None or post is None:
                 # the connection does not go to a child of this network,
                 # so ignore it.
-                print('error processing', c)
+                logger.error('error processing %s', c)
             else:
                 edges[c] = Edge(vertices[pre], vertices[post], data=c)
 

--- a/nengo_gui/main.py
+++ b/nengo_gui/main.py
@@ -10,9 +10,12 @@ from nengo_gui.guibackend import ModelContext, GuiServerSettings
 from nengo_gui.password import gensalt, hashpw, prompt_pw
 
 
+logger = logging.getLogger(__name__)
+
+
 def old_main():
-    print("'nengo_gui' has been renamed to 'nengo'.")
-    print("Please run 'nengo' in the future to avoid this message!\n")
+    logger.info("'nengo_gui' has been renamed to 'nengo'.")
+    logger.info("Please run 'nengo' in the future to avoid this message!\n")
     main()
 
 

--- a/nengo_gui/main.py
+++ b/nengo_gui/main.py
@@ -49,9 +49,9 @@ def main():
     args = parser.parse_args()
 
     if args.debug:
-        logging.basicConfig(level=logging.DEBUG)
+        logging.basicConfig(format='%(message)s', level=logging.DEBUG)
     else:
-        logging.basicConfig()
+        logging.basicConfig(format='%(message)s', level=logging.INFO)
 
     if args.password:
         if args.password is True:

--- a/nengo_gui/page.py
+++ b/nengo_gui/page.py
@@ -14,6 +14,9 @@ import nengo_gui.user_action
 import nengo_gui.config
 
 
+logger = logging.getLogger(__name__)
+
+
 class PageSettings(object):
     __slots__ = ['backend', 'editor_class', 'filename_cfg']
 
@@ -259,7 +262,7 @@ class Page(object):
                 except Exception:
                     # FIXME
                     #if self.gui.interactive:
-                    logging.debug('error parsing config: %s', line)
+                    logger.debug('error parsing config: %s', line)
 
         # make sure the required Components exist
         if '_viz_sim_control' not in self.locals:
@@ -313,8 +316,8 @@ class Page(object):
                 with open(self.filename_cfg, 'w') as f:
                     f.write(self.config.dumps(uids=self.default_labels))
             except IOError:
-                print("Could not save %s; permission denied" %
-                      self.filename_cfg)
+                logger.exception("Could not save %s; permission denied" %
+                                 self.filename_cfg)
 
     def modified_config(self):
         """Set a flag that the config file should be saved."""
@@ -407,7 +410,7 @@ class Page(object):
             del self.locals[uid]
             del self.default_labels[obj]
         else:
-            print('WARNING: remove_uid called on unknown uid: %s' % uid)
+            logger.warning('remove_uid called on unknown uid: %s', uid)
 
     def remove_component(self, component):
         """Remove a component from the layout."""

--- a/nengo_gui/password.py
+++ b/nengo_gui/password.py
@@ -5,7 +5,11 @@ from __future__ import print_function
 import binascii
 from getpass import getpass
 import hashlib
+import logging
 import os
+
+
+logger = logging.getLogger(__name__)
 
 
 def gensalt(size=16):
@@ -27,4 +31,4 @@ def prompt_pw():
         p1 = getpass("Enter password: ")
         if p0 == p1:
             return p0
-        print("Passwords do not match. Please try again.")
+        logger.error("Passwords do not match. Please try again.")

--- a/nengo_gui/password.py
+++ b/nengo_gui/password.py
@@ -1,7 +1,5 @@
 """Password hashing functions replicating bcrypt API."""
 
-from __future__ import print_function
-
 import binascii
 from getpass import getpass
 import hashlib

--- a/nengo_gui/tests/test_basic_functionality.py
+++ b/nengo_gui/tests/test_basic_functionality.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import time
 


### PR DESCRIPTION
This pull request fixes #290. All modules fetch a module specific ``logger`` object which is then used to log messages previously printed with ``print``, or ``logging.`` without a ``logger`` object.

This patchset should not significantly change the output of nengo_gui visible to the user. A future improvement would be a nice formater, which may print the log severity and other information.  Note that all messages are now written to ``stderr`` instead of ``stdout``.

Note that this patch set touches various places all over the code, it should thus be reviewed thoroughly.

Things which need to be checked before merging this pull request:
- [ ] Were the log severities chosen correctly?
- [ ] Does lowering the default log level have any unwanted side-effects?
- [ ] Can the calls to the ``warnings``-module in ``ipython.py`` be safely replaced by calls to ``logging``? My guess was no, so I didn't change anything here.