### PR TITLE
Add dual stack IPv6 support.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,7 @@ Release History
 0.3.2 (unreleased)
 ==================
 
-
+- Dual-stack IPv4/IPv6 support
 
 0.3.1 (October 17, 2017)
 ========================

--- a/nengo_gui/guibackend.py
+++ b/nengo_gui/guibackend.py
@@ -365,9 +365,10 @@ class GuiServer(server.ManagedThreadHttpServer):
         server.ManagedThreadHttpServer.__init__(
             self, self.settings.listen_addr, GuiRequestHandler)
         if self.settings.use_ssl:
-            self.socket = ssl.wrap_socket(
-                self.socket, certfile=self.settings.ssl_cert,
-                keyfile=self.settings.ssl_key, server_side=True)
+            for b in self.bindings:
+                b.socket = ssl.wrap_socket(
+                    b.socket, certfile=self.settings.ssl_cert,
+                    keyfile=self.settings.ssl_key, server_side=True)
 
         self.sessions = SessionManager(self.settings.session_duration)
 

--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -139,10 +139,18 @@ class DualStackHttpServer(object):
         self.server_name, self.server_port = server_address
 
         self.bindings = []
-        for fam, socktype, _, _, addr in socket.getaddrinfo(*server_address):
-            if (fam in (socket.AF_INET, socket.AF_INET6) and
-                    socktype is socket.SOCK_STREAM):
-                self.bindings.append(self.Binding(fam, addr))
+        if self.server_name == '':
+            self.bindings.append(self.Binding(
+                socket.AF_INET, ('', self.server_port)))
+            if socket.has_ipv6:
+                self.bindings.append(self.Binding(
+                    socket.AF_INET6, ('::', self.server_port)))
+        else:
+            for fam, socktype, _, _, addr in socket.getaddrinfo(
+                    *server_address):
+                if (fam in (socket.AF_INET, socket.AF_INET6) and
+                        socktype in (0, socket.SOCK_STREAM)):
+                    self.bindings.append(self.Binding(fam, addr))
 
         self.RequestHandlerClass = RequestHandlerClass
 

--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -28,6 +28,19 @@ logger = logging.getLogger(__name__)
 WS_MAGIC = '258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
 
 
+if socket.has_ipv6:
+    if hasattr(socket, 'IPPROTO_IPV6'):
+        IPPROTO_IPV6 = socket.IPPROTO_IPV6
+    elif sys.platform.startswith('win'):
+        # See <https://bugs.python.org/issue29515>.
+        IPPROTO_IPV6 = 41
+    else:
+        raise RuntimeError(
+            "System does not define IPPROTO_IPV6 despite IPv6 support.")
+else:
+    IPPROTO_IPV6 = None
+
+
 class SocketClosedError(IOError):
     pass
 
@@ -120,7 +133,7 @@ class DualStackHttpServer(object):
                 self.address_family, socket.SOCK_STREAM)
             if self.address_family is socket.AF_INET6:
                 self.socket.setsockopt(
-                    socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
+                    IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
 
         def bind(self):
             self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)


### PR DESCRIPTION
This implements support for IPv6 with a dual stack solution supporting IPv4 and IPv6 at the same time. In theory this also allows to listen on multiple ports or network interfaces at the same time. But this is not exposed within `main.py`, so the `nengo` command only allows to listen on all `localhost` addresses (no password protection) or all interfaces (with password protection). I assume this to be fine in almost all cases and do not intend to change this as long as there are no such requests because it would complicate the interface without need.

Due to the current implementation of the WebSocket origin checking the GUI does not support access by IP address (e.g. `127.0.0.1` or `[::]`), except when started with a password.

Addresses #21.