### PR TITLE
Fix websocket upgrade in Safari.

### DIFF
--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -265,11 +265,11 @@ class HttpWsRequestHandler(server.BaseHTTPRequestHandler):
         raise NotImplementedError()
 
     def upgrade_to_ws(self):
-        response = '''HTTP/1.1 101 Switching Protocols
-Upgrade: websocket
-Connection: Upgrade
-Sec-WebSocket-Accept: {sec}
-
+        response = '''HTTP/1.1 101 Switching Protocols\r\n\
+Upgrade: websocket\r\n\
+Connection: Upgrade\r\n\
+Sec-WebSocket-Accept: {sec}\r\n\
+\r\n\
 '''
         valid_srv_addrs = self.get_expected_origins()
 


### PR DESCRIPTION
Safari requires the line ending to be \r\n, other forms are
disallowed.

Fixes #880.