### PR TITLE
More informative message when making a Simulator in the GUI

### DIFF
--- a/nengo_gui/exec_env.py
+++ b/nengo_gui/exec_env.py
@@ -117,6 +117,11 @@ class ExecutionEnvironment(object):
 
         sys.stdout = sys.__stdout__
 
+        # ensure what has been printed is safe to show in html
+        s = self.stdout.getvalue()
+        s = s.replace('<', '&lt;').replace('>', '&gt;')
+        self.stdout = StringIO(s)
+
         if not self.allow_sim:
             if self.added_directory is not None:
                 sys.path.remove(self.added_directory)

--- a/nengo_gui/page.py
+++ b/nengo_gui/page.py
@@ -223,11 +223,12 @@ class Page(object):
             exec_env.stdout.write('Warning: Simulators cannot be manually'
                                   ' run inside nengo_gui (line %d)\n' % line)
             exec_env.stdout.write('\nIf you are running a Nengo script from'
-                                  ' a tutorial, this may be a tutorial\nthat'
-                                  ' should be run in a Python interpreter,'
-                                  ' rather than in the Nengo GUI.\nSee'
-                                  ' https://nengo.github.io/users.html'
-                                  ' for more details.\n')
+                ' a tutorial, this may be a tutorial\nthat'
+                ' should be run in a Python interpreter,'
+                ' rather than in the Nengo GUI.\nSee'
+                ' <a href="https://nengo.github.io/users.html"'
+                '  target="_blank">https://nengo.github.io/users.html</a>'
+                ' for more details.\n')
         except nengo_gui.exec_env.StartedGUIException:
             line = nengo_gui.exec_env.determine_line_number()
             exec_env.stdout.write('Warning: nengo_gui cannot be run inside'

--- a/nengo_gui/page.py
+++ b/nengo_gui/page.py
@@ -222,6 +222,12 @@ class Page(object):
             line = nengo_gui.exec_env.determine_line_number()
             exec_env.stdout.write('Warning: Simulators cannot be manually'
                                   ' run inside nengo_gui (line %d)\n' % line)
+            exec_env.stdout.write('\nIf you are running a Nengo script from'
+                                  ' a tutorial, this may be a tutorial\nthat'
+                                  ' should be run in a Python interpreter,'
+                                  ' rather than in the Nengo GUI.\nSee'
+                                  ' https://nengo.github.io/users.html'
+                                  ' for more details.\n')
         except nengo_gui.exec_env.StartedGUIException:
             line = nengo_gui.exec_env.determine_line_number()
             exec_env.stdout.write('Warning: nengo_gui cannot be run inside'

--- a/nengo_gui/static/ace.js
+++ b/nengo_gui/static/ace.js
@@ -201,7 +201,7 @@ Nengo.Ace.prototype.on_message = function (event) {
             this.marker = null;
             this.editor.getSession().clearAnnotations();
         }
-        $(this.console_stdout).text(msg.stdout);
+        $(this.console_stdout).html(msg.stdout);
         $(this.console_error).text('');
         this.console.scrollTop = this.console.scrollHeight;
     } else if (msg.filename !== undefined) {
@@ -222,7 +222,7 @@ Nengo.Ace.prototype.on_message = function (event) {
             type: 'error',
             text: msg.short_msg,
         }]);
-        $(this.console_stdout).text(msg.stdout);
+        $(this.console_stdout).html(msg.stdout);
         $(this.console_error).text(msg.error.trace);
         this.console.scrollTop = this.console.scrollHeight;
     } else {


### PR DESCRIPTION
A number of new users have asked questions like this one:

https://forum.nengo.ai/t/how-to-see-the-plots/282

where they are taking Nengo examples and pasting them into the GUI (rather than running them in a Python interpreter). 

This PR gives a more informative error message when this happens, and directs them to a web page that gives more detail.

There are 2 commits here -- the first one gives the error message, and the second one makes the link work.  I've separated them like that because it's a bit annoying how I'm getting a HTML from the server to the client -- we used to assume that this was always text, not HTML.  If someone has a better way to do this, that'd be good too.