### PR TITLE
Fix learning rules on sliced connections

### DIFF
--- a/nengo_gui/layout.py
+++ b/nengo_gui/layout.py
@@ -109,7 +109,7 @@ class Layout(object):
             if isinstance(post, nengo.connection.LearningRule):
                 post = post.connection.post
                 if isinstance(post, nengo.base.ObjView):
-                    post = post.object
+                    post = post.obj
             if isinstance(post, nengo.ensemble.Neurons):
                 post = post.ensemble
             while post not in vertices:


### PR DESCRIPTION
The following model breaks `nengo_gui`:

```python
import nengo

model = nengo.Network()
with model:
    stim = nengo.Node([0])
    a = nengo.Ensemble(n_neurons=50, dimensions=1)
    b = nengo.Ensemble(n_neurons=50, dimensions=1)
    nengo.Connection(stim, a)
    conn = nengo.Connection(a, b[0], learning_rule_type=nengo.PES())
    
    stim2 = nengo.Node([0])
     
    nengo.Connection(stim2, conn.learning_rule)
```

This produces

```
Traceback (most recent call last):
  File "c:\users\terry\documents\github\nengo_gui\nengo_gui\guibackend.py", line 230, in ws_default
    component.update_client(self.ws)
  File "c:\users\terry\documents\github\nengo_gui\nengo_gui\components\netgraph.py", line 399, in update_client
    self.expand_network(network, client)
  File "c:\users\terry\documents\github\nengo_gui\nengo_gui\components\netgraph.py", line 492, in expand_network
    pos = self.layout.make_layout(network)
  File "c:\users\terry\documents\github\nengo_gui\nengo_gui\layout.py", line 112, in make_layout
    post = post.object
```

The problem is exactly that last line in the stack trace.  It should have been `post.obj`.

This should fix #893 