### PR TITLE
Fix WebSocket compatibility with Safari.

### DIFF
--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -265,12 +265,11 @@ class HttpWsRequestHandler(server.BaseHTTPRequestHandler):
         raise NotImplementedError()
 
     def upgrade_to_ws(self):
-        response = '''HTTP/1.1 101 Switching Protocols\r\n\
-Upgrade: websocket\r\n\
-Connection: Upgrade\r\n\
-Sec-WebSocket-Accept: {sec}\r\n\
-\r\n\
-'''
+        response = (
+            'HTTP/1.1 101 Switching Protocols\r\n'
+            'Upgrade: websocket\r\n'
+            'Connection: Upgrade\r\n'
+            'Sec-WebSocket-Accept: {sec}\r\n\r\n')
         valid_srv_addrs = self.get_expected_origins()
 
         try:


### PR DESCRIPTION
Safari complains if the line break is not CRLF, but only LF.

This is cherry-picked from #808 (which has been marked as reviewed more than 9 months ago, but got never merged 😒 Anyways, the newer #864 should be merged before #808 now, but people ran into problems with Safari, so that really should get fixed.)