### PR TITLE
Token based authentication

### DIFF
--- a/nengo_gui/gui.py
+++ b/nengo_gui/gui.py
@@ -70,8 +70,9 @@ class InteractiveGUI(BaseGUI):
 
     def start(self):
         protocol = 'https:' if self.server.settings.use_ssl else 'http:'
-        print("Starting nengo server at %s//%s:%d" %
-              (protocol, 'localhost', self.server.server_port))
+        print("Starting nengo server accessible at:\n  %s//%s:%d/?token=%s" % (
+            protocol, 'localhost', self.server.server_port,
+            self.server.settings.auth_token))
 
         if not sys.platform.startswith('win'):
             signal.signal(signal.SIGINT, self._confirm_shutdown)
@@ -141,7 +142,9 @@ class GUI(InteractiveGUI):
     def start(self):
         t = threading.Thread(
             target=webbrowser.open,
-            args=('http://localhost:%d' % self.server.server_port,))
+            args=('http://localhost:%d/?token=%s' % (
+                self.server.server_port,
+                self.server.settings.auth_token,)))
         t.start()
 
         super(GUI, self).start()

--- a/nengo_gui/gui.py
+++ b/nengo_gui/gui.py
@@ -72,7 +72,7 @@ class InteractiveGUI(BaseGUI):
         protocol = 'https:' if self.server.settings.use_ssl else 'http:'
         print("Starting nengo server accessible at:\n  %s//%s:%d/?token=%s" % (
             protocol, 'localhost', self.server.server_port,
-            self.server.settings.auth_token))
+            self.server.auth_token))
 
         if not sys.platform.startswith('win'):
             signal.signal(signal.SIGINT, self._confirm_shutdown)

--- a/nengo_gui/guibackend.py
+++ b/nengo_gui/guibackend.py
@@ -110,16 +110,8 @@ class GuiRequestHandler(server.HttpWsRequestHandler):
     }
 
     def get_expected_origins(self):
-        session = self.get_session()
-        has_password = self.server.settings.password_hash is not None
-        origins = []
-        if not has_password:
-            origins.append('localhost:' + str(self.server.server_port))
-            if self.server.server_port in [80, 443]:
-                origins.append('localhost')
-        elif session.login_host is not None:
-            return [session.login_host]
-        return origins
+        login_host = self.get_session().login_host
+        return [login_host] if login_host is not None else []
 
     def login_page(self):
         session = self.get_session()

--- a/nengo_gui/ipython.py
+++ b/nengo_gui/ipython.py
@@ -91,7 +91,7 @@ class IPythonViz(object):
             try:
                 s = socket.create_connection((self.host, self.port), 0.1)
                 self._started = True
-            except:
+            except Exception:
                 pass
             else:
                 s.close()

--- a/nengo_gui/ipython.py
+++ b/nengo_gui/ipython.py
@@ -40,13 +40,16 @@ class IPythonViz(object):
         self._server_thread, server = self.start_server(cfg, model)
         self.port = server.server.server_port
 
-        self.url = self.get_url(self.host, self.port)
+        self.url = self.get_url(
+            self.host, self.port, token=server.server.settings.auth_token)
 
     @staticmethod
-    def get_url(host, port, action=None):
-        url = 'http://{host}:{port}'.format(host=host, port=port)
+    def get_url(host, port, action=None, token=None):
+        url = 'http://{host}:{port}/'.format(host=host, port=port)
         if action is not None:
-            url += '/' + action
+            url += action
+        if token is not None:
+            url += '?token=' + token
         return url
 
     @classmethod

--- a/nengo_gui/main.py
+++ b/nengo_gui/main.py
@@ -103,7 +103,8 @@ def main():
             port = s.server.server_port
             t = threading.Thread(
                 target=webbrowser.open,
-                args=('%s//%s:%d' % (protocol, host, port),))
+                args=('%s//%s:%d/?token=%s' % (
+                    protocol, host, port, server_settings.auth_token),))
             t.start()
 
         s.start()

--- a/nengo_gui/main.py
+++ b/nengo_gui/main.py
@@ -104,7 +104,7 @@ def main():
             t = threading.Thread(
                 target=webbrowser.open,
                 args=('%s//%s:%d/?token=%s' % (
-                    protocol, host, port, server_settings.auth_token),))
+                    protocol, host, port, s.server.gen_one_time_token()),))
             t.start()
 
         s.start()

--- a/nengo_gui/password.py
+++ b/nengo_gui/password.py
@@ -19,6 +19,7 @@ def hashpw(password, salt, algorithm='sha1'):
     return algorithm + ':' + salt + ':' + h.hexdigest()
 
 
+
 def checkpw(password, hashed):
     algorithm, salt, _ = hashed.split(':')
     return hashpw(password, salt, algorithm) == hashed


### PR DESCRIPTION
This resolves some security problems on multi-user systems. Prior to these changes any user on the local system could have connected to the Nengo GUI server to run arbitrary code under the permissions of a different user. With the token based authentication such an evil user has to obtain the token first.

This is similar to how Jupyter Notebook handles things.
    
Fixes #867. Also fixes some Python 3 issues with the password protection.

Another benefit is that this allows to automatically login into a password protected server. Though maybe that might give the impression that the password protection does not work?

At the moment the only way to have a Nengo GUI server that listens for outside connections is to spawn a password protected server. I wonder whether we should add the possibility to allow outside connections even without a password as the token based authentication will still be required? If so, should this be restricted to SSL connections? (I think Jupyter Notebook only allows to enable outside connections only together with SSL and it probably makes sense as sniffing the token gives full access.) Of course one could set a password (hopefully secure) dummy password and still use the token ...