### PR TITLE
Fixes to the HTTP response headers

### DIFF
--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -95,7 +95,8 @@ class HttpResponse(object):
 
     def send(self, request):
         request.send_response(self.code)
-        request.send_header('Content-type', self.mimetype)
+        request.send_header('Content-Type', self.mimetype)
+        request.send_header('Content-Length', len(self.data))
         if hasattr(request, 'flush_headers'):
             request.flush_headers()
         request.wfile.write(request.cookie.output().encode('utf-8'))

--- a/nengo_gui/server.py
+++ b/nengo_gui/server.py
@@ -99,8 +99,10 @@ class HttpResponse(object):
         request.send_header('Content-Length', len(self.data))
         if hasattr(request, 'flush_headers'):
             request.flush_headers()
-        request.wfile.write(request.cookie.output().encode('utf-8'))
-        request.wfile.write(b'\r\n')
+        cookie = request.cookie.output().encode('utf-8')
+        if len(cookie) > 0:
+            request.wfile.write(cookie)
+            request.wfile.write(b'\r\n')
         for header in self.headers:
             request.send_header(*header)
         request.end_headers()


### PR DESCRIPTION
Add the content length field to the header as otherwise certain clients might not read all data and prevent an empty line (effectively ending the headers) when no cookies are set.