### PR TITLE
Fix crash with voltage graph

### DIFF
--- a/nengo_gui/components/voltage.py
+++ b/nengo_gui/components/voltage.py
@@ -10,8 +10,9 @@ from nengo_gui.components.component import Component
 class Voltage(Component):
     """Represents neuron voltage over time."""
 
-    config_defaults = dict(
-        max_value=5.0, min_value=0.0, **Component.config_defaults)
+    config_defaults = dict(max_value=5.0, min_value=0.0,
+                           show_legend=False, legend_labels=[],
+                           **Component.config_defaults)
 
     def __init__(self, obj, n_neurons=5):
         super(Voltage, self).__init__()


### PR DESCRIPTION
The voltage plot is broken at the moment, as [reported on the forum](https://forum.nengo.ai/t/on-and-off-error-signal-neurons-of-ensemble-a-voltage-slice-none-5-none-shape-5/417/1). I'm not sure when that started, but it seems to be an issue with voltage re-using the Value plot infrastructure in JavaScript, but not Python. This should be done better, and it is in the refactoring, but for the time being this PR fixes the voltage plot crash.