### PR TITLE
Connection types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Release History
 0.3.2 (unreleased)
 ==================
 
+- Added visual depiction of modulatory and inhibitory connections
 - Token-based authentication
 - Dual-stack IPv4/IPv6 support
 

--- a/nengo_gui/static/components/netgraph.css
+++ b/nengo_gui/static/components/netgraph.css
@@ -29,6 +29,23 @@ g.net rect{
     stroke-width: 2px;
 }
 
+.netgraph g.inhibitory > line {
+    stroke: #c00000;
+}
+
+.netgraph g.inhibitory > path {
+    fill: #c00000;
+}
+
+.netgraph g.modulatory > line {
+    stroke: #8eb627;
+    stroke-dasharray: 1em;
+}
+
+.netgraph g.modulatory > path {
+    fill: #8eb627;
+}
+
 .minimap {
     border-radius: 10px/60px;
     height: 100%;

--- a/nengo_gui/static/components/netgraph_conn.js
+++ b/nengo_gui/static/components/netgraph_conn.js
@@ -343,24 +343,32 @@ Nengo.NetGraphConnection.prototype.redraw = function() {
         if (post_to_pre_angle < -Math.PI) {post_to_pre_angle+=2*Math.PI;}
         var post_length = this.intersect_length(post_to_pre_angle, a2, w2, h2);
 
-        var mx = (pre_pos[0]+pre_length[0]) * 0.4
-                    + (post_pos[0]+post_length[0]) * 0.6;
-        var my = (pre_pos[1]+pre_length[1]) * 0.4
-                    + (post_pos[1]+post_length[1]) * 0.6;
+        let mx, my;
+        if (this.kind == 'modulatory') {
+            // Just centre modulatory connection markers on the post object
+            mx = post_pos[0]
+            my = post_pos[1]
+        } else {
+            mx = (pre_pos[0]+pre_length[0]) * 0.4
+                        + (post_pos[0]+post_length[0]) * 0.6;
+            my = (pre_pos[1]+pre_length[1]) * 0.4
+                        + (post_pos[1]+post_length[1]) * 0.6;
 
-        //Check to make sure the marker doesn't go past either endpoint
-        vec1 = [post_pos[0]-pre_pos[0], post_pos[1]-pre_pos[1]];
-        vec2 = [mx-pre_pos[0], my-pre_pos[1]];
-        dot_prod = (vec1[0]*vec2[0] + vec1[1]*vec2[1])
-            / (vec1[0]*vec1[0]+vec1[1]*vec1[1]);
+            //Check to make sure the marker doesn't go past either endpoint
+            vec1 = [post_pos[0]-pre_pos[0], post_pos[1]-pre_pos[1]];
+            vec2 = [mx-pre_pos[0], my-pre_pos[1]];
+            dot_prod = (vec1[0]*vec2[0] + vec1[1]*vec2[1])
+                / (vec1[0]*vec1[0]+vec1[1]*vec1[1]);
 
-        if (dot_prod < 0) {
-            mx = pre_pos[0];
-            my = pre_pos[1];
-        } else if (dot_prod>1){
-            mx = post_pos[0];
-            my = post_pos[1];
+            if (dot_prod < 0) {
+                mx = pre_pos[0];
+                my = pre_pos[1];
+            } else if (dot_prod>1){
+                mx = post_pos[0];
+                my = post_pos[1];
+            }
         }
+
         angle = 180 / Math.PI * angle;
         this.marker.setAttribute('transform',
                           'translate(' + mx + ',' + my + ') rotate('+ angle +')');

--- a/nengo_gui/static/components/netgraph_conn.js
+++ b/nengo_gui/static/components/netgraph_conn.js
@@ -38,6 +38,7 @@ Nengo.NetGraphConnection = function(ng, info, minimap, mini_conn) {
      *  until it finds one that does exist. */
     this.pres = info.pre;
     this.posts = info.post;
+    this.kind = info.kind;
 
     this.recurrent = this.pres[0] === this.posts[0];
 
@@ -57,6 +58,7 @@ Nengo.NetGraphConnection = function(ng, info, minimap, mini_conn) {
 
     /** create the line and its arrowhead marker */
     this.g = ng.createSVGElement('g');
+    this.g.classList.add(this.kind);
 
     this.create_line();
 
@@ -88,7 +90,18 @@ Nengo.NetGraphConnection.prototype.create_line = function() {
         this.g.appendChild(this.marker);
 
         if (this.minimap == false) {
-            this.marker.setAttribute('d', "M 6.5 0 L 0 5.0 L 7.5 8.0 z");
+            switch (this.kind) {
+                case "inhibitory":
+                    this.marker.setAttribute('d', "M 7,7 C 10.5,3.5 7,0 7,0 L 0,7 c 0,0 3.5,3.5 7,0 z");
+                    break;
+                case "modulatory":
+                    this.marker.setAttribute('d', "M 7.5,0 0,-5 -7.5,0 0,5 z");
+                    break;
+                case "normal":
+                default:
+                    this.marker.setAttribute('d', "M 6.5 0 L 0 5.0 L 7.5 8.0 z");
+                    break;
+            }
         } else {
             this.marker.setAttribute('d', "M 4 0 L 0 2 L 4 4 z");
         }
@@ -98,7 +111,18 @@ Nengo.NetGraphConnection.prototype.create_line = function() {
         this.g.appendChild(this.line);
         this.marker = this.ng.createSVGElement('path');
         if (this.minimap == false) {
-            this.marker.setAttribute('d', "M 10 0 L -5 -5 L -5 5 z");
+            switch (this.kind) {
+                case "inhibitory":
+                    this.marker.setAttribute('d', "M 4,0 C 4,-8 -4,-8 -4,-8 V 8 c 0,0 8,0 8,-8 z");
+                    break;
+                case "modulatory":
+                    this.marker.setAttribute('d', "M 7.5,0 0,-5 -7.5,0 0,5 z");
+                    break;
+                case "normal":
+                default:
+                    this.marker.setAttribute('d', "M 10 0 L -5 -5 L -5 5 z");
+                    break;
+            }
         } else {
             this.marker.setAttribute('d', "M 3 0 L -2.5 -2.5 L -2.5 2.5 z");
         }

--- a/nengo_gui/tests/test_netgraph.py
+++ b/nengo_gui/tests/test_netgraph.py
@@ -1,0 +1,70 @@
+'''
+Tests for the NetGraph class.
+'''
+
+import numpy as np
+
+import nengo
+from nengo_gui.components.netgraph import NetGraph
+
+
+def test_get_pre_post_obj():
+    model = nengo.Network()
+    with model:
+        a = nengo.Ensemble(1, 10)
+        b = nengo.Ensemble(1, 10)
+        conn = nengo.Connection(a, b)
+    assert a == NetGraph.connection_pre_obj(conn)
+    assert b == NetGraph.connection_post_obj(conn)
+    assert "normal" == NetGraph.connection_kind(conn)
+
+
+def test_get_pre_post_obj_neurons():
+    model = nengo.Network()
+    with model:
+        a = nengo.Ensemble(1, 10)
+        b = nengo.Ensemble(1, 10)
+        conn = nengo.Connection(a.neurons, b.neurons)
+    assert a == NetGraph.connection_pre_obj(conn)
+    assert b == NetGraph.connection_post_obj(conn)
+    assert "normal" == NetGraph.connection_kind(conn)
+
+
+def test_get_pre_post_obj_learning_rule():
+    model = nengo.Network()
+    with model:
+        a = nengo.Ensemble(1, 10)
+        b = nengo.Ensemble(1, 10)
+        c = nengo.Ensemble(1, 10)
+        conn_1 = nengo.Connection(a, b)
+        conn_1.learning_rule_type = nengo.PES()
+        conn_2 = nengo.Connection(c, conn_1.learning_rule)
+    assert a == NetGraph.connection_pre_obj(conn_1)
+    assert b == NetGraph.connection_post_obj(conn_1)
+    assert "normal" == NetGraph.connection_kind(conn_1)
+
+    assert c == NetGraph.connection_pre_obj(conn_2)
+    assert b == NetGraph.connection_post_obj(conn_2)
+    assert "modulatory" == NetGraph.connection_kind(conn_2)
+
+
+def test_connection_inhibitory():
+    model = nengo.Network()
+    with model:
+        a = nengo.Ensemble(1, 10)
+        b = nengo.Ensemble(1, 10)
+        conn_1 = nengo.Connection(a, b.neurons, transform=1 * np.ones((1, 10)))
+        conn_2 = nengo.Connection(
+            a, b.neurons, transform=-1 * np.ones((1, 10)))
+        conn_3 = nengo.Connection(
+            a,
+            b.neurons,
+            transform=np.array((0, -1, 0, 0, 0, 0, 0, 0, 0, 0)).reshape((1,
+                                                                         10)))
+        conn_4 = nengo.Connection(
+            a, b.neurons, transform=-1 * np.zeros((1, 10)))
+    assert "normal" == NetGraph.connection_kind(conn_1)
+    assert "inhibitory" == NetGraph.connection_kind(conn_2)
+    assert "inhibitory" == NetGraph.connection_kind(conn_3)
+    assert "normal" == NetGraph.connection_kind(conn_4)
+


### PR DESCRIPTION
This is a first implementation of #598.

![Example of new connection types](https://i.imgur.com/T1b9v8Y.png)

I've split the code into four small commits, I think it makes most sense to go through these those independently when reviewing.

To summarise:
* *Commit 1*: Is the entire server-side implementation. Adds the connection `kind` to the `info` structure. This should be fairly tidy, and I've added some unit-tests here.
* *Commit 2*: Is a essentially a two-line change to the Python code adding the `kind` as a `class` and some changes to the CSS for adapting stroke and colour according to the `kind`. Furthermore, I changed the marker symbols for non-normal connections (inspired by what I usually end up using when I manually draw these diagrams in Inkscape, see [1]; it's trivial to change that to something else), though I did not touch the marker symbol code for minimaps.
* *Commit 3*: Is a minimal change which just centres the marker on the post-object in case the connection is modulatory.
* *Commit 4*:  Series of dirty hacks on the client-side to allow connections to connection objects.


[1] https://rawgithub.com/astoeckel/syde_750_project_lifespan_inference/master/doc/media/diag_px.svg