### PR TITLE
Add syntax highlighting for nengo_spa.Actions.

### DIFF
--- a/nengo_gui/static/ace.js
+++ b/nengo_gui/static/ace.js
@@ -33,7 +33,7 @@ Nengo.Ace = function (uid, args) {
     code_div.id = 'editor'
     $('#rightpane').append(code_div);
     this.editor = ace.edit('editor')
-    this.editor.getSession().setMode("ace/mode/python");
+    this.editor.getSession().setMode("ace/mode/spa");
     this.editor.gotoLine(1);
     this.marker = null;
 

--- a/nengo_gui/static/mode-spa.js
+++ b/nengo_gui/static/mode-spa.js
@@ -1,0 +1,99 @@
+define('ace/mode/spa', function(require, exports, module) {
+
+var oop = require("ace/lib/oop");
+var PythonMode = require("ace/mode/python").Mode;
+var SpaHighlightRules = require("ace/mode/spa_highlight_rules").SpaHighlightRules;
+
+var Mode = function() {
+    this.HighlightRules = SpaHighlightRules;
+};
+oop.inherits(Mode, PythonMode);
+
+(function() {
+    // Extra logic goes here.
+}).call(Mode.prototype);
+
+exports.Mode = Mode;
+});
+
+
+define('ace/mode/spa_highlight_rules', function(require, exports, module) {
+
+var oop = require("ace/lib/oop");
+var PythonHighlightRules = require("ace/mode/python_highlight_rules").PythonHighlightRules;
+
+var SpaHighlightRules = function() {
+
+    var stringEscape = "\\\\(x[0-9A-Fa-f]{2}|[0-7]{3}|[\\\\abfnrtv'\"]|U[0-9A-Fa-f]{8}|u[0-9A-Fa-f]{4})";
+    this.$rules = new PythonHighlightRules().getRules();
+    this.$rules.start.splice(0, 0, {
+        token: "keyword",
+        regex: "spa\\s*\\.\\s*Actions\\([uUrR]?'(?!'')",
+        next: "spa_q_start"
+    }, {
+        token: "keyword",
+        regex: "spa\\s*\\.\\s*Actions\\([uUrR]?\"(?!\"\")",
+        next: "spa_qq_start"
+    }, {
+        token: "keyword",
+        regex: "spa\\s*\\.\\s*Actions\\([uUrR]?'''",
+        next: "spa_q3_start"
+    }, {
+        token: "keyword",
+        regex: "spa\\s*\\.\\s*Actions\\([uUrR]?\"{3}",
+        next: "spa_qq3_start"
+    });
+
+    var spa_rules = [{
+        token: "keyword",
+        regex: "\\b(ifmax|elifmax)\\b"
+    }, {
+        token: "support.function",
+        regex: "\\b(dot|reinterpret|translate)\\b"
+    }, {
+        token: "support.constant",
+        regex: "\\b[A-Z][_0-9a-zA-Z]*\\b"
+    }];
+
+    this.embedRules(PythonHighlightRules, "spa_q_", [{
+        token: "constant.languag.escape",
+        regex: stringEscape,
+    }]);
+    this.$rules.spa_q_start = spa_rules.concat([{
+        token: "keyword",
+        regex: "'(\\s*\\))?|$",
+        next: "start",
+    }].concat(this.$rules.spa_q_start));
+    this.embedRules(PythonHighlightRules, "spa_qq_", [{
+        token: "constant.languag.escape",
+        regex: stringEscape,
+        }]);
+    this.$rules.spa_qq_start = spa_rules.concat([{
+        token: "keyword",
+        regex: "\"(\\s*\\))?|$",
+        next: "start",
+    }].concat(this.$rules.spa_qq_start));
+    this.embedRules(PythonHighlightRules, "spa_q3_", [{
+        token: "constant.languag.escape",
+        regex: stringEscape,
+    }]);
+    this.$rules.spa_q3_start = spa_rules.concat([{
+        token: "keyword",
+        regex: "'''\\s*\\)",
+        next: "start",
+    }].concat(this.$rules.spa_q3_start));
+    this.embedRules(PythonHighlightRules, "spa_qq3_", [{
+        token: "constant.languag.escape",
+        regex: stringEscape,
+    }]);
+    this.$rules.spa_qq3_start = spa_rules.concat([{
+        token: "keyword",
+        regex: "\"{3}\\s*\\)",
+        next: "start",
+    }].concat(this.$rules.spa_qq3_start));
+}
+
+oop.inherits(SpaHighlightRules, PythonHighlightRules);
+
+exports.SpaHighlightRules = SpaHighlightRules;
+});

--- a/nengo_gui/static/mode-spa.js
+++ b/nengo_gui/static/mode-spa.js
@@ -56,7 +56,7 @@ var SpaHighlightRules = function() {
     }];
 
     this.embedRules(PythonHighlightRules, "spa_q_", [{
-        token: "constant.languag.escape",
+        token: "constant.language.escape",
         regex: stringEscape,
     }]);
     this.$rules.spa_q_start = spa_rules.concat([{
@@ -65,7 +65,7 @@ var SpaHighlightRules = function() {
         next: "start",
     }].concat(this.$rules.spa_q_start));
     this.embedRules(PythonHighlightRules, "spa_qq_", [{
-        token: "constant.languag.escape",
+        token: "constant.language.escape",
         regex: stringEscape,
         }]);
     this.$rules.spa_qq_start = spa_rules.concat([{
@@ -74,7 +74,7 @@ var SpaHighlightRules = function() {
         next: "start",
     }].concat(this.$rules.spa_qq_start));
     this.embedRules(PythonHighlightRules, "spa_q3_", [{
-        token: "constant.languag.escape",
+        token: "constant.language.escape",
         regex: stringEscape,
     }]);
     this.$rules.spa_q3_start = spa_rules.concat([{
@@ -83,7 +83,7 @@ var SpaHighlightRules = function() {
         next: "start",
     }].concat(this.$rules.spa_q3_start));
     this.embedRules(PythonHighlightRules, "spa_qq3_", [{
-        token: "constant.languag.escape",
+        token: "constant.language.escape",
         regex: stringEscape,
     }]);
     this.$rules.spa_qq3_start = spa_rules.concat([{

--- a/nengo_gui/templates/page.html
+++ b/nengo_gui/templates/page.html
@@ -171,6 +171,8 @@
             }
         </script>
         <script src="static/lib/js/ace-src-min/ace.js" type="text/javascript" charset="utf-8"></script>
+        <script src="static/lib/js/ace-src-min/mode-python.js" type="text/javascript" charset="utf-8"></script>
+        <script src="static/mode-spa.js" type="text/javascript" charset="utf-8"></script>
         <script src="static/lib/js/interact-1.2.4.js"></script>
         <script src="static/lib/js/d3.v3.min.js" charset="utf-8"></script>
         <script src="static/lib/js/jquery-2.1.3.min.js"></script>


### PR DESCRIPTION
This adds a first attempt on syntax highlighting for `nengo_spa.Actions` to the Nengo GUI editor (as requested in nengo/nengo_spa#91). The syntax highlighting can probably still improved and there might be cases that are not properly covered.

* The highlighting is detected by the string `spa.Actions(` which should work for `nengo_spa.Actions` too, but in theory `spa` and `Actions` could have completely different names or someone could do `from nengo_spa import Actions`. These cases are not covered (and cannot be covered without executing the Python code which is a bad idea in a syntax highlighter).
* Around the `.` and the `(` one could have newlines, these are not supported (not sure if the JS regexes can be made to match newlines). Other whitespace is allowed.
* The actions use the normal Python highlighter with some rules for new keywords (`ifmax`, `elifmax`) etc added in. There might be some Python highlighting rules that should not apply inside the actions, but I'm not sure ... (too lazy to think through all the cases and remove those rules)
* Every identifier starting with a capital letter will be highlighted as Semantic Pointer even though it might be a variable or class name.
* The builtins `dot`, `reinterpret`, and `translate` are highlighted as such.
* Because the action rules use mostly normal highlighting they don't stand out very much. Not sure if there is a way to improve that. the surrounding `spa.Actions(...)` will be highlighted as keyword, not sure if it should be highlighted and as what (but it might help to visually delimit the actions block).

There is also an issue with loading this syntax highlighting rules. The ACE editor is supposed to be loaded with  `requirejs` which we are not doing (ACE is doing it itself for us, but that leaves some path configuration unconfigured). Thus, the highlighting cannot be dynamically loaded as it is supposed to be done and the `mode-python.js` and `mode-spa.js` need to be manually loaded in the HTML. I suppose that will be fixed in the refactoring and as fixing it likely requires some reorganization of our JavaScript files I have no intention in doing so.

And finally, a screenshot showing off the highlighting:
<img width="589" alt="highlight" src="https://user-images.githubusercontent.com/850157/32411613-4753a39c-c1b6-11e7-9f75-f866c28690ad.png">
